### PR TITLE
ZON-2898: Add colorpicker for article teaser images

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.article changes
 3.15.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add colorpicker for article teaser images (ZON-2898).
 
 
 3.15.1 (2016-03-10)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'zeit.connector>=2.3.1.dev0',
         'zeit.content.author>=2.4.0.dev0',
         'zeit.content.cp>=0.33.0',
-        'zeit.content.image',
+        'zeit.content.image>=2.13.0.dev0',
         'zeit.content.infobox',
         'zeit.content.gallery',
         'zeit.content.portraitbox',

--- a/src/zeit/content/article/browser/tests/test_form.py
+++ b/src/zeit/content/article/browser/tests/test_form.py
@@ -114,38 +114,6 @@ class TestAdding(zeit.cms.testing.BrowserTestCase):
         article = self.get_article()
         self.assertTrue(ISemanticChange(article).last_semantic_change)
 
-    def test_png_teaser_images_should_enable_colorpicker(self):
-        from zeit.content.image.testing import (
-            create_image_group_with_master_image)
-        with zeit.cms.testing.site(self.getRootFolder()):
-            with zeit.cms.testing.interaction():
-                article = zeit.content.article.testing.create_article()
-                group = create_image_group_with_master_image(
-                    file_name='http://xml.zeit.de/2016/DSC00109_2.PNG')
-                zeit.content.image.interfaces.IImages(article).image = group
-                self.repository['article'] = article
-        b = self.browser
-        b.open(
-            'http://localhost/++skin++vivi/repository/article/@@checkout')
-        b.open('@@edit.form.teaser-image?show_form=1')
-        b.getControl(name='teaser-image.fill_color')
-
-    def test_non_png_teaser_images_should_not_enable_colorpicker(self):
-        from zeit.content.image.testing import (
-            create_image_group_with_master_image)
-        with zeit.cms.testing.site(self.getRootFolder()):
-            with zeit.cms.testing.interaction():
-                article = zeit.content.article.testing.create_article()
-                group = create_image_group_with_master_image()
-                zeit.content.image.interfaces.IImages(article).image = group
-                self.repository['article'] = article
-        b = self.browser
-        b.open(
-            'http://localhost/++skin++vivi/repository/article/@@checkout')
-        b.open('@@edit.form.teaser-image?show_form=1')
-        with self.assertRaises(LookupError):
-            b.getControl(name='teaser-image.fill_color')
-
 
 class DefaultView(zeit.cms.testing.BrowserTestCase):
 

--- a/src/zeit/content/article/browser/tests/test_form.py
+++ b/src/zeit/content/article/browser/tests/test_form.py
@@ -114,6 +114,38 @@ class TestAdding(zeit.cms.testing.BrowserTestCase):
         article = self.get_article()
         self.assertTrue(ISemanticChange(article).last_semantic_change)
 
+    def test_png_teaser_images_should_enable_colorpicker(self):
+        from zeit.content.image.testing import (
+            create_image_group_with_master_image)
+        with zeit.cms.testing.site(self.getRootFolder()):
+            with zeit.cms.testing.interaction():
+                article = zeit.content.article.testing.create_article()
+                group = create_image_group_with_master_image(
+                    file_name='http://xml.zeit.de/2016/DSC00109_2.PNG')
+                zeit.content.image.interfaces.IImages(article).image = group
+                self.repository['article'] = article
+        b = self.browser
+        b.open(
+            'http://localhost/++skin++vivi/repository/article/@@checkout')
+        b.open('@@edit.form.teaser-image?show_form=1')
+        b.getControl(name='teaser-image.fill_color')
+
+    def test_non_png_teaser_images_should_not_enable_colorpicker(self):
+        from zeit.content.image.testing import (
+            create_image_group_with_master_image)
+        with zeit.cms.testing.site(self.getRootFolder()):
+            with zeit.cms.testing.interaction():
+                article = zeit.content.article.testing.create_article()
+                group = create_image_group_with_master_image()
+                zeit.content.image.interfaces.IImages(article).image = group
+                self.repository['article'] = article
+        b = self.browser
+        b.open(
+            'http://localhost/++skin++vivi/repository/article/@@checkout')
+        b.open('@@edit.form.teaser-image?show_form=1')
+        with self.assertRaises(LookupError):
+            b.getControl(name='teaser-image.fill_color')
+
 
 class DefaultView(zeit.cms.testing.BrowserTestCase):
 

--- a/src/zeit/content/article/edit/browser/form.py
+++ b/src/zeit/content/article/edit/browser/form.py
@@ -408,7 +408,8 @@ class TeaserImage(zeit.edit.browser.form.InlineForm):
         try:
             master = zeit.content.image.interfaces.IMasterImage(
                 zeit.content.image.interfaces.IImages(self.context).image)
-            if master.format == 'PNG':
+            if master.format == 'PNG' and (
+                    self.form_fields.get('fill_color') is None):
                 self.form_fields += FormFields(
                     zeit.content.image.interfaces.IImages).select('fill_color')
                 self.form_fields['fill_color'].custom_widget = (

--- a/src/zeit/content/article/edit/browser/form.py
+++ b/src/zeit/content/article/edit/browser/form.py
@@ -408,14 +408,13 @@ class TeaserImage(zeit.edit.browser.form.InlineForm):
         try:
             master = zeit.content.image.interfaces.IMasterImage(
                 zeit.content.image.interfaces.IImages(self.context).image)
-            if master.format == 'PNG' and (
-                    self.form_fields.get('fill_color') is None):
+            if master.format == 'PNG':
                 self.form_fields += FormFields(
                     zeit.content.image.interfaces.IImages).select('fill_color')
                 self.form_fields['fill_color'].custom_widget = (
                     zeit.cms.browser.widget.ColorpickerWidget)
         except TypeError:
-            self.form_fields = self.form_fields.omit('fill_color')
+            pass
         super(TeaserImage, self).setUpWidgets(*args, **kw)
         self.widgets['image'].add_type = IImageGroup
 

--- a/src/zeit/content/article/edit/browser/form.py
+++ b/src/zeit/content/article/edit/browser/form.py
@@ -162,7 +162,7 @@ class NewFilename(zeit.edit.browser.form.InlineForm):
             render_context=zope.formlib.interfaces.DISPLAY_UNWRITEABLE).select(
                 '__name__', 'rename_to')
         if zeit.cms.repository.interfaces.IAutomaticallyRenameable(
-            self.context).renameable:
+                self.context).renameable:
             form_fields = form_fields.omit('__name__')
         else:
             form_fields = form_fields.omit('rename_to')
@@ -405,6 +405,16 @@ class TeaserImage(zeit.edit.browser.form.InlineForm):
         return super(TeaserImage, self).__call__()
 
     def setUpWidgets(self, *args, **kw):
+        try:
+            master = zeit.content.image.interfaces.IMasterImage(
+                zeit.content.image.interfaces.IImages(self.context).image)
+            if master.format == 'PNG':
+                self.form_fields += FormFields(
+                    zeit.content.image.interfaces.IImages).select('fill_color')
+                self.form_fields['fill_color'].custom_widget = (
+                    zeit.cms.browser.widget.ColorpickerWidget)
+        except TypeError:
+            self.form_fields = self.form_fields.omit('fill_color')
         super(TeaserImage, self).setUpWidgets(*args, **kw)
         self.widgets['image'].add_type = IImageGroup
 

--- a/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/src/zeit/content/article/edit/browser/resources/editor.css
@@ -1559,6 +1559,12 @@
   width: 9em;
 }
 
+.type-article #edit-form-teaser #teaser-image\.fill_color {
+  margin-top: 10px;
+  width: 137px;
+}
+
+
 .type-article #form-teaser-supertitle .widget,
 .type-article #form-teaser-title .widget,
 .type-article #form-teaser-text .widget {

--- a/src/zeit/content/article/edit/browser/tests/test_reference.py
+++ b/src/zeit/content/article/edit/browser/tests/test_reference.py
@@ -48,6 +48,38 @@ class ImageForm(zeit.content.article.edit.browser.testing.BrowserTestCase):
         b.getControl('Apply').click()
         self.assertFalse(self.get_image_block().set_manually)
 
+    def test_png_teaser_images_should_enable_colorpicker(self):
+        from zeit.content.image.testing import (
+            create_image_group_with_master_image)
+        with zeit.cms.testing.site(self.getRootFolder()):
+            with zeit.cms.testing.interaction():
+                article = zeit.content.article.testing.create_article()
+                group = create_image_group_with_master_image(
+                    file_name='http://xml.zeit.de/2016/DSC00109_2.PNG')
+                zeit.content.image.interfaces.IImages(article).image = group
+                self.repository['article'] = article
+        b = self.browser
+        b.open(
+            'http://localhost/++skin++vivi/repository/article/@@checkout')
+        b.open('@@edit.form.teaser-image?show_form=1')
+        b.getControl(name='teaser-image.fill_color')
+
+    def test_non_png_teaser_images_should_not_enable_colorpicker(self):
+        from zeit.content.image.testing import (
+            create_image_group_with_master_image)
+        with zeit.cms.testing.site(self.getRootFolder()):
+            with zeit.cms.testing.interaction():
+                article = zeit.content.article.testing.create_article()
+                group = create_image_group_with_master_image()
+                zeit.content.image.interfaces.IImages(article).image = group
+                self.repository['article'] = article
+        b = self.browser
+        b.open(
+            'http://localhost/++skin++vivi/repository/article/@@checkout')
+        b.open('@@edit.form.teaser-image?show_form=1')
+        with self.assertRaises(LookupError):
+            b.getControl(name='teaser-image.fill_color')
+
 
 class ImageEditTest(zeit.content.article.edit.browser.testing.EditorTestCase):
 


### PR DESCRIPTION
https://github.com/ZeitOnline/zeit.content.image/pull/4
https://github.com/ZeitOnline/zeit.content.cp/pull/9
https://github.com/ZeitOnline/zeit.cms/pull/10
https://github.com/ZeitOnline/zeit.content.article/pull/2
