### PR TITLE
Revert "ZON-2898: Simplify spelling"

### DIFF
--- a/src/zeit/content/article/edit/browser/form.py
+++ b/src/zeit/content/article/edit/browser/form.py
@@ -408,13 +408,14 @@ class TeaserImage(zeit.edit.browser.form.InlineForm):
         try:
             master = zeit.content.image.interfaces.IMasterImage(
                 zeit.content.image.interfaces.IImages(self.context).image)
-            if master.format == 'PNG':
+            if master.format == 'PNG' and (
+                    self.form_fields.get('fill_color') is None):
                 self.form_fields += FormFields(
                     zeit.content.image.interfaces.IImages).select('fill_color')
                 self.form_fields['fill_color'].custom_widget = (
                     zeit.cms.browser.widget.ColorpickerWidget)
         except TypeError:
-            pass
+            self.form_fields = self.form_fields.omit('fill_color')
         super(TeaserImage, self).setUpWidgets(*args, **kw)
         self.widgets['image'].add_type = IImageGroup
 

--- a/src/zeit/content/article/edit/browser/tests/test_reference.py
+++ b/src/zeit/content/article/edit/browser/tests/test_reference.py
@@ -80,6 +80,9 @@ class ImageForm(zeit.content.article.edit.browser.testing.BrowserTestCase):
         with self.assertRaises(LookupError):
             b.getControl(name='teaser-image.fill_color')
 
+    # XXX Need test for removal of color picker through removal of image
+    # reference
+
 
 class ImageEditTest(zeit.content.article.edit.browser.testing.EditorTestCase):
 


### PR DESCRIPTION
This reverts commit a3a2538b851efcfe1899b290cc314a572915c400.

Because this breaks correct removal of colorpicker
