### PR TITLE
ZON-2927: Split Image.layout into display_mode and variant_name

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ zeit.content.article changes
 3.15.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Split image layout into two separate attributes to avoid combinatorial
+  explosion (ZON-2927).
 
 
 3.15.7 (2016-04-26)

--- a/src/zeit/content/article/article.py
+++ b/src/zeit/content/article/article.py
@@ -114,16 +114,28 @@ class Article(zeit.cms.content.metadata.CommonMetadata):
         image_block.references = value
 
     @property
-    def main_image_layout(self):
+    def main_image_display_mode(self):
         image_block = self.main_image_block
         if image_block is None:
             return None
-        return image_block.layout
+        return image_block.display_mode
 
-    @main_image_layout.setter
-    def main_image_layout(self, value):
+    @main_image_display_mode.setter
+    def main_image_display_mode(self, value):
         image_block = self.main_image_block
-        image_block.layout = value
+        image_block.display_mode = value
+
+    @property
+    def main_image_variant_name(self):
+        image_block = self.main_image_block
+        if image_block is None:
+            return None
+        return image_block.variant_name
+
+    @main_image_variant_name.setter
+    def main_image_variant_name(self, value):
+        image_block = self.main_image_block
+        image_block.variant_name = value
 
     def _create_image_block_in_front(self):
         body = zeit.content.article.edit.interfaces.IEditableBody(self)

--- a/src/zeit/content/article/edit/browser/form.py
+++ b/src/zeit/content/article/edit/browser/form.py
@@ -94,7 +94,7 @@ class ArticleContentMainImage(zeit.edit.browser.form.InlineForm):
     prefix = 'article-content-main-image'
     undo_description = _('edit article content main image')
     form_fields = FormFields(IArticle).select(
-        'main_image', 'main_image_layout')
+        'main_image', 'main_image_display_mode', 'main_image_variant_name')
 
     def __call__(self):
         zope.interface.alsoProvides(

--- a/src/zeit/content/article/edit/browser/reference.py
+++ b/src/zeit/content/article/edit/browser/reference.py
@@ -32,7 +32,7 @@ class EditBase(zeit.edit.browser.form.InlineForm):
 class EditImage(EditBase):
 
     interface = zeit.content.article.edit.interfaces.IImage
-    fields = ('references', 'layout')
+    fields = ('references', 'display_mode', 'variant_name')
     undo_description = _('edit image block')
 
     def setUpWidgets(self, *args, **kw):

--- a/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/src/zeit/content/article/edit/browser/resources/editor.css
@@ -1429,7 +1429,6 @@
   padding-right: 2em;
 }
 
-.type-article #form-article-content-main-image > .fieldname-main_image_layout,
 .type-article #form-article-content-main-image > .fieldname-main_image,
 .type-article #form-article-content-main-image .widget,
 .type-article #form-article-content-main-image .object-widget {
@@ -1437,19 +1436,8 @@
   padding:0;
 }
 
-.type-article #form-article-content-main-image > .fieldname-main_image_layout,
 .type-article .fieldname-main_image_layout .widget{
    width: 50% !important;
-}
-
-.type-article #form-article-content-main-image > .fieldname-main_image_layout{
-  position:relative;
-  top: -2.1em;
-  left: 19em;
-}
-
-.type-article #form-article-content-main-image > .fieldname-main_image_layout div.value:before{
-  content:"Layout: ";
 }
 
 

--- a/src/zeit/content/article/edit/browser/resources/editor.css
+++ b/src/zeit/content/article/edit/browser/resources/editor.css
@@ -245,7 +245,7 @@
 
 /* Teaser: Knopf und Artikel */
 
-.type-article #edit-form-article-content.editable-area > .block-inner > .inline-form .label label,
+.type-article #form-article-content-head .label label,
 .type-article #edit-form-teaser.editable-area .label label {
   display: none;
 }
@@ -922,6 +922,7 @@
   padding: 0;
 }
 
+.type-article #article-content-main-image\.main_image .label,
 .type-article #edit-form-article-content .block.type-raw .field.fieldname-xml .label,
 .type-article #edit-form-article-content .block.type-image .field.fieldname-references .label,
 .type-article #edit-form-article-content .block.type-gallery .field.fieldname-references .label,
@@ -1473,11 +1474,6 @@
   padding:0;
 }
 
-.type-article .fieldname-main_image_layout .widget{
-   width: 50% !important;
-}
-
-
 /* TEASER AREA */
 
 .type-article #edit-form-teaser .inline-form .object-widget {
@@ -2027,4 +2023,33 @@
 .find-dialog label[for=find-dialog-replacement] {
     display: inline-block;
     width: 10em;
+}
+
+
+.type-article #edit-form-article-content .inline-form.wired .field.fieldname-main_image_display_mode,
+.type-article #edit-form-article-content .inline-form.wired .field.fieldname-main_image_variant_name,
+.type-article #edit-form-article-content .inline-form.wired .field.fieldname-display_mode,
+.type-article #edit-form-article-content .inline-form.wired .field.fieldname-variant_name {
+    float: left;
+    width: auto;
+    clear: none;
+}
+
+.type-article #form-article-content-main-image > .fieldname-main_image_display_mode,
+.type-article #form-article-content-main-image > .fieldname-main_image_variant_name {
+  position: relative;
+  top: -2.1em;
+  left: 19em;
+}
+
+.type-article #form-article-content-main-image .label {
+    display: none;
+}
+.type-article #form-article-content-main-image > .fieldname-main_image_display_mode div.value:before {
+    content: "Layout";
+    float: left;
+    padding-right: 0.5em;
+    color: #4c4c4c;
+    font-weight: bold;
+    text-transform: uppercase;
 }

--- a/src/zeit/content/article/edit/configure.zcml
+++ b/src/zeit/content/article/edit/configure.zcml
@@ -107,13 +107,6 @@
       />
   </class>
 
-  <class class=".interfaces.ImageLayout">
-    <require
-      interface=".interfaces.IImageLayout"
-      permission="zope.View"
-      />
-  </class>
-
   <class class=".video.Video">
     <require
       interface=".interfaces.IVideo"

--- a/src/zeit/content/article/edit/image.py
+++ b/src/zeit/content/article/edit/image.py
@@ -53,6 +53,9 @@ class Image(zeit.content.article.edit.reference.Reference):
 
     def __init__(self, *args, **kw):
         super(Image, self).__init__(*args, **kw)
+        # Explicitly set `display_mode` and `variant_name` to persist values
+        # calculated from legacy attribute `layout` to XML, so the mapping for
+        # backward compatibility is only performed once.
         if self._display_mode is None:
             self.display_mode = self.display_mode
         if self._variant_name is None:

--- a/src/zeit/content/article/edit/image.py
+++ b/src/zeit/content/article/edit/image.py
@@ -65,15 +65,11 @@ class Image(zeit.content.article.edit.reference.Reference):
     def display_mode(self):
         if self._display_mode is not None:
             return self._display_mode
-
         # backward compatibility by mapping old layout to display_mode
         layout = self.xml.get('layout', None)
         mapping = dict(list(LEGACY_DISPLAY_MODE_SOURCE(self)))
-        if layout in mapping:
-            return mapping[layout]
-
-        return zeit.content.article.edit.interfaces.IImage[
-            'display_mode'].default
+        return mapping.get(layout, zeit.content.article.edit.interfaces.IImage[
+            'display_mode'].default)
 
     @display_mode.setter
     def display_mode(self, value):
@@ -83,15 +79,11 @@ class Image(zeit.content.article.edit.reference.Reference):
     def variant_name(self):
         if self._variant_name is not None:
             return self._variant_name
-
         # backward compatibility by mapping old layout to display_mode
         layout = self.xml.get('layout', None)
         mapping = dict(list(LEGACY_VARIANT_NAME_SOURCE(self)))
-        if layout in mapping:
-            return mapping[layout]
-
-        return zeit.content.article.edit.interfaces.IImage[
-            'variant_name'].default
+        return mapping.get(layout, zeit.content.article.edit.interfaces.IImage[
+            'variant_name'].default)
 
     @variant_name.setter
     def variant_name(self, value):

--- a/src/zeit/content/article/edit/image.py
+++ b/src/zeit/content/article/edit/image.py
@@ -1,4 +1,6 @@
 from zeit.cms.i18n import MessageFactory as _
+from zeit.content.article.edit.interfaces import LEGACY_DISPLAY_MODE_SOURCE
+from zeit.content.article.edit.interfaces import LEGACY_VARIANT_NAME_SOURCE
 import grokcore.component
 import lxml.objectify
 import zeit.cms.checkout.interfaces
@@ -9,57 +11,6 @@ import zeit.content.article.interfaces
 import zeit.content.image.interfaces
 import zeit.edit.interfaces
 import zope.lifecycleevent
-
-
-# Required for backward compatibility, since the `layout` setting did contain a
-# combination of `display_mode` and `variant_name`.
-LAYOUT_DISPLAY_MODE_MAPPING = {
-    'column-width': 'column-width',
-    'column-width-original': 'column-width',
-    'column-width-portrait': 'column-width',
-    'column-width-square': 'column-width',
-    'float-portrait': 'float',
-    'float-square': 'float',
-    'large': 'large',
-    'portrait': 'float',
-    'small': 'float',
-    'zco-portrait': 'large',
-    'zco-wide': 'large',
-}
-
-
-# Required for backward compatibility, since the `layout` setting did contain a
-# combination of `display_mode` and `variant_name`.
-LAYOUT_VARIANT_NAME_MAPPING = {
-    'column-width': 'wide',
-    'column-width-original': 'original',
-    'column-width-portrait': 'portrait',
-    'column-width-square': 'square',
-    'float-portrait': 'portrait',
-    'float-square': 'square',
-    'large': 'wide',
-    'portrait': 'original',
-    'small': 'wide',
-    'zco-portrait': 'portrait',
-    'zco-wide': 'wide',
-    'zmo-large-center': 'wide',
-    'zmo-medium-center': 'wide',
-    'zmo-medium-left': 'wide',
-    'zmo-medium-right': 'wide',
-    'zmo-narrow-header': 'narrow',
-    'zmo-portrait-header': 'portrait',
-    'zmo-small-left': 'portrait',
-    'zmo-small-left-original': 'original',
-    'zmo-small-right': 'portrait',
-    'zmo-small-right-original': 'original',
-    'zmo-square-header': 'square',
-    'zmo-standard-header': 'standard',
-    'zmo-super-header': 'super',
-    'zmo-tile-header': 'tile',
-    'zmo-wide-header': 'wide',
-    'zmo-xl': 'super',
-    'zmo-xl-header': 'original',
-}
 
 
 class ImageReferenceProperty(
@@ -114,8 +65,9 @@ class Image(zeit.content.article.edit.reference.Reference):
 
         # backward compatibility by mapping old layout to display_mode
         layout = self.xml.get('layout', None)
-        if layout in LAYOUT_DISPLAY_MODE_MAPPING:
-            return LAYOUT_DISPLAY_MODE_MAPPING[layout]
+        mapping = dict(list(LEGACY_DISPLAY_MODE_SOURCE(self)))
+        if layout in mapping:
+            return mapping[layout]
 
         return zeit.content.article.edit.interfaces.IImage[
             'display_mode'].default
@@ -131,8 +83,9 @@ class Image(zeit.content.article.edit.reference.Reference):
 
         # backward compatibility by mapping old layout to display_mode
         layout = self.xml.get('layout', None)
-        if layout in LAYOUT_VARIANT_NAME_MAPPING:
-            return LAYOUT_VARIANT_NAME_MAPPING[layout]
+        mapping = dict(list(LEGACY_VARIANT_NAME_SOURCE(self)))
+        if layout in mapping:
+            return mapping[layout]
 
         return zeit.content.article.edit.interfaces.IImage[
             'variant_name'].default

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -204,6 +204,20 @@ class ImageDisplayModeSource(zeit.cms.content.sources.XMLSource):
 IMAGE_DISPLAY_MODE_SOURCE = ImageDisplayModeSource()
 
 
+class LegacyDisplayModeSource(zeit.cms.content.sources.XMLSource):
+    """Source to map legacy attr `layout` to a corresponding `display_mode`."""
+
+    product_configuration = 'zeit.content.article'
+    config_url = 'legacy-display-mode-source'
+
+    def getValues(self, context):
+        tree = self._get_tree()
+        return [(node.get('layout'), node.get('display_mode'))
+                for node in tree.iterchildren('*')]
+
+LEGACY_DISPLAY_MODE_SOURCE = LegacyDisplayModeSource()
+
+
 class ImageVariantNameSource(zeit.cms.content.sources.XMLSource):
 
     product_configuration = 'zeit.content.article'
@@ -212,6 +226,20 @@ class ImageVariantNameSource(zeit.cms.content.sources.XMLSource):
     title_xpath = '/variant-names/variant-name'
 
 IMAGE_VARIANT_NAME_SOURCE = ImageVariantNameSource()
+
+
+class LegacyVariantNameSource(zeit.cms.content.sources.XMLSource):
+    """Source to map legacy attr `layout` to a corresponding `variant_name`."""
+
+    product_configuration = 'zeit.content.article'
+    config_url = 'legacy-variant-name-source'
+
+    def getValues(self, context):
+        tree = self._get_tree()
+        return [(node.get('layout'), node.get('variant_name'))
+                for node in tree.iterchildren('*')]
+
+LEGACY_VARIANT_NAME_SOURCE = LegacyVariantNameSource()
 
 
 class IImage(IReference):

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -201,7 +201,7 @@ class ImageDisplayModeSource(zeit.cms.content.sources.XMLSource):
     attribute = 'id'
     title_xpath = '/display-modes/display-mode'
 
-imageDisplayModeSource = ImageDisplayModeSource()
+IMAGE_DISPLAY_MODE_SOURCE = ImageDisplayModeSource()
 
 
 class ImageVariantNameSource(zeit.cms.content.sources.XMLSource):
@@ -211,7 +211,7 @@ class ImageVariantNameSource(zeit.cms.content.sources.XMLSource):
     attribute = 'id'
     title_xpath = '/variant-names/variant-name'
 
-imageVariantNameSource = ImageVariantNameSource()
+IMAGE_VARIANT_NAME_SOURCE = ImageVariantNameSource()
 
 
 class IImage(IReference):
@@ -229,13 +229,13 @@ class IImage(IReference):
 
     display_mode = zope.schema.Choice(
         title=_('Display Mode'),
-        source=imageDisplayModeSource,
+        source=IMAGE_DISPLAY_MODE_SOURCE,
         default=u'large',
         required=False)
 
     variant_name = zope.schema.Choice(
         title=_('Variant Name'),
-        source=imageVariantNameSource,
+        source=IMAGE_VARIANT_NAME_SOURCE,
         default=u'wide',
         required=False)
 

--- a/src/zeit/content/article/edit/tests/image-display-modes.xml
+++ b/src/zeit/content/article/edit/tests/image-display-modes.xml
@@ -1,0 +1,4 @@
+<display-modes>
+  <display-mode id="large">Large</display-mode>
+  <display-mode id="float">Float</display-mode>
+</display-modes>

--- a/src/zeit/content/article/edit/tests/image-layouts.xml
+++ b/src/zeit/content/article/edit/tests/image-layouts.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<image-layouts>
-  <layout id="small" display_mode="float" available="zeit.cms.section.interfaces.IZONContent">small</layout>
-  <!-- default value must not use available -->
-  <layout id="large" display_mode="fullwidth">large</layout>
-  <layout id="upright" available="zeit.cms.section.interfaces.IZONContent">upright</layout>
-  <layout id="stamp" variant_name="square" display_mode="float">Stamp</layout>
-  <layout id="zmo-only" available="zeit.magazin.interfaces.IZMOContent">zmo</layout>
-</image-layouts>

--- a/src/zeit/content/article/edit/tests/image-variant-names.xml
+++ b/src/zeit/content/article/edit/tests/image-variant-names.xml
@@ -1,0 +1,6 @@
+<variant-names>
+  <variant-name id="wide">Breit</variant-name>
+  <variant-name id="original">Original</variant-name>
+  <variant-name id="square">Square 1:1</variant-name>
+  <variant-name id="zmo-only" available="zeit.magazin.interfaces.IZMOContent">ZMO Only</variant-name>
+</variant-names>

--- a/src/zeit/content/article/edit/tests/legacy-display-modes.xml
+++ b/src/zeit/content/article/edit/tests/legacy-display-modes.xml
@@ -1,0 +1,5 @@
+<legacy-display-modes>
+  <legacy-mapping layout="float-portrait" display_mode="float" />
+  <legacy-mapping layout="float-square" display_mode="float" />
+  <legacy-mapping layout="large" display_mode="large" />
+</legacy-display-modes>

--- a/src/zeit/content/article/edit/tests/legacy-variant-names.xml
+++ b/src/zeit/content/article/edit/tests/legacy-variant-names.xml
@@ -1,0 +1,5 @@
+<legacy-variant-names>
+  <legacy-mapping layout="float-portrait" variant_name="portrait" />
+  <legacy-mapping layout="float-square" variant_name="square" />
+  <legacy-mapping layout="large" variant_name="wide" />
+</legacy-variant-names>

--- a/src/zeit/content/article/edit/tests/test_image.py
+++ b/src/zeit/content/article/edit/tests/test_image.py
@@ -280,18 +280,18 @@ class ImageTest(zeit.content.article.testing.FunctionalTestCase):
             yield image
 
     def test_variant_name_available_walks_up_to_article(self):
-        from zeit.content.article.edit.interfaces import imageVariantNameSource
+        import zeit.content.article.edit.interfaces
         with self.image() as image:
-            self.assertEqual(
-                ['wide', 'original', 'square'],
-                list(imageVariantNameSource(image)))
+            self.assertEqual(['wide', 'original', 'square'], list(
+                zeit.content.article.edit.interfaces.IMAGE_VARIANT_NAME_SOURCE(
+                    image)))
 
     def test_display_mode_available_walks_up_to_article(self):
-        from zeit.content.article.edit.interfaces import imageDisplayModeSource
+        import zeit.content.article.edit.interfaces
         with self.image() as image:
-            self.assertEqual(
-                ['large', 'float'],
-                list(imageDisplayModeSource(image)))
+            self.assertEqual(['large', 'float'], list(
+                zeit.content.article.edit.interfaces.IMAGE_DISPLAY_MODE_SOURCE(
+                    image)))
 
     def test_display_mode_defaults_to_layout_if_not_set_for_bw_compat(self):
         from zeit.content.article.edit.image import Image

--- a/src/zeit/content/article/edit/tests/test_image.py
+++ b/src/zeit/content/article/edit/tests/test_image.py
@@ -7,21 +7,22 @@ class ImageTest(zeit.content.article.testing.FunctionalTestCase):
 
     def test_image_can_be_set(self):
         from zeit.content.article.edit.image import Image
-        from zeit.content.article.edit.interfaces import imageLayoutSource
         import lxml.objectify
         import zeit.cms.interfaces
         tree = lxml.objectify.E.tree(
             lxml.objectify.E.image())
         image = Image(None, tree.image)
         image.__name__ = u'myname'
-        image.layout = imageLayoutSource(None).find('large')
+        image.display_mode = u'float'
+        image.variant_name = u'square'
         image_uid = 'http://xml.zeit.de/2006/DSC00109_2.JPG'
         image.references = image.references.create(
             zeit.cms.interfaces.ICMSContent(image_uid))
         self.assertEqual(image_uid, image.references.target.uniqueId)
         self.assertEqual(image_uid, image.xml.get('src'))
         self.assertEqual(u'myname', image.__name__)
-        self.assertEqual(u'large', image.layout.id)
+        self.assertEqual(u'float', image.display_mode)
+        self.assertEqual(u'square', image.variant_name)
         self.assertEllipsis("""\
 <image ... src="{image_uid}" ... is_empty="False">
   <bu xsi:nil="true"/>
@@ -278,36 +279,41 @@ class ImageTest(zeit.content.article.testing.FunctionalTestCase):
                 ICMSContent('http://xml.zeit.de/2006/DSC00109_2.JPG'))
             yield image
 
-    def test_layout_source_returns_objects(self):
-        from zeit.content.article.edit.interfaces import imageLayoutSource
-        layout = imageLayoutSource(None).find('stamp')
-        self.assertEqual('stamp', layout.id)
-        self.assertEqual('Stamp', layout.title)
-        self.assertEqual('square', layout.variant)
-        self.assertEqual('float', layout.display_mode)
-
-    def test_layout_available_walks_up_to_article(self):
-        from zeit.content.article.edit.interfaces import imageLayoutSource
+    def test_variant_name_available_walks_up_to_article(self):
+        from zeit.content.article.edit.interfaces import imageVariantNameSource
         with self.image() as image:
-            layouts = [x.id for x in imageLayoutSource(image)]
-        self.assertNotIn('zmo-only', layouts)
+            self.assertEqual(
+                ['wide', 'original', 'square'],
+                list(imageVariantNameSource(image)))
 
-    def test_layouts_are_compared_using_their_id(self):
-        from zeit.content.article.edit.interfaces import ImageLayout
-        layout = ImageLayout('foo', 'Foo')
-        other = ImageLayout('foo', 'Ninja')
-        self.assertEqual(layout, other)
+    def test_display_mode_available_walks_up_to_article(self):
+        from zeit.content.article.edit.interfaces import imageDisplayModeSource
+        with self.image() as image:
+            self.assertEqual(
+                ['large', 'float'],
+                list(imageDisplayModeSource(image)))
 
-    def test_layout_can_be_compared_to_string(self):
-        from zeit.content.article.edit.interfaces import ImageLayout
-        layout = ImageLayout('foo', 'Foo')
-        self.assertEqual(layout, 'foo')
-        self.assertNotEqual(layout, 'bar')
+    def test_display_mode_defaults_to_layout_if_not_set_for_bw_compat(self):
+        from zeit.content.article.edit.image import Image
+        import lxml.objectify
+        tree = lxml.objectify.E.tree(lxml.objectify.E.image())
+        tree.image.set('layout', 'float-square')
+        image = Image(None, tree.image)
+        self.assertEqual('float', image.display_mode)
 
-    def test_alyout_can_be_compared_to_None(self):
-        from zeit.content.article.edit.interfaces import ImageLayout
-        layout = ImageLayout('foo', 'Foo')
-        self.assertNotEqual(layout, None)
+        image.xml.set('display_mode', 'large')
+        self.assertEqual('large', image.display_mode)
+
+    def test_variant_name_defaults_to_layout_if_not_set_for_bw_compat(self):
+        from zeit.content.article.edit.image import Image
+        import lxml.objectify
+        tree = lxml.objectify.E.tree(lxml.objectify.E.image())
+        tree.image.set('layout', 'float-square')
+        image = Image(None, tree.image)
+        self.assertEqual('square', image.variant_name)
+
+        image.xml.set('variant_name', 'original')
+        self.assertEqual('original', image.variant_name)
 
 
 class TestFactory(zeit.content.article.testing.FunctionalTestCase):

--- a/src/zeit/content/article/interfaces.py
+++ b/src/zeit/content/article/interfaces.py
@@ -56,9 +56,14 @@ class IArticleMetadata(zeit.cms.content.interfaces.ICommonMetadata):
         source=zeit.content.image.interfaces.imageSource,
         required=False)
 
-    main_image_layout = zope.schema.Choice(
-        title=_("Layout"),
-        source=zeit.content.article.edit.interfaces.imageLayoutSource,
+    main_image_display_mode = zope.schema.Choice(
+        title=_('Display Mode'),
+        source=zeit.content.article.edit.interfaces.imageDisplayModeSource,
+        required=False)
+
+    main_image_variant_name = zope.schema.Choice(
+        title=_('Variant Name'),
+        source=zeit.content.article.edit.interfaces.imageVariantNameSource,
         required=False)
 
     main_image_block = zope.interface.Attribute(

--- a/src/zeit/content/article/interfaces.py
+++ b/src/zeit/content/article/interfaces.py
@@ -58,12 +58,12 @@ class IArticleMetadata(zeit.cms.content.interfaces.ICommonMetadata):
 
     main_image_display_mode = zope.schema.Choice(
         title=_('Display Mode'),
-        source=zeit.content.article.edit.interfaces.imageDisplayModeSource,
+        source=zeit.content.article.edit.interfaces.IMAGE_DISPLAY_MODE_SOURCE,
         required=False)
 
     main_image_variant_name = zope.schema.Choice(
         title=_('Variant Name'),
-        source=zeit.content.article.edit.interfaces.imageVariantNameSource,
+        source=zeit.content.article.edit.interfaces.IMAGE_VARIANT_NAME_SOURCE,
         required=False)
 
     main_image_block = zope.interface.Attribute(

--- a/src/zeit/content/article/testing.py
+++ b/src/zeit/content/article/testing.py
@@ -23,7 +23,9 @@ product_config = """
     book-recension-categories file://{base}/tests/recension_categories.xml
     genre-url file://{base}/tests/article-genres.xml
     image-display-mode-source file://{base}/edit/tests/image-display-modes.xml
+    legacy-display-mode-source file://{base}/edit/tests/legacy-display-modes.xml
     image-variant-name-source file://{base}/edit/tests/image-variant-names.xml
+    legacy-variant-name-source file://{base}/edit/tests/legacy-variant-names.xml
     video-layout-source file://{base}/edit/tests/video-layouts.xml
     htmlblock-layout-source file://{base}/edit/tests/htmlblock-layouts.xml
     infobox-layout-source file://{base}/edit/tests/infobox-layouts.xml

--- a/src/zeit/content/article/testing.py
+++ b/src/zeit/content/article/testing.py
@@ -22,7 +22,8 @@ product_config = """
     cds-import-invalid-path cds/invalid/$$year/$$volume
     book-recension-categories file://{base}/tests/recension_categories.xml
     genre-url file://{base}/tests/article-genres.xml
-    image-layout-source file://{base}/edit/tests/image-layouts.xml
+    image-display-mode-source file://{base}/edit/tests/image-display-modes.xml
+    image-variant-name-source file://{base}/edit/tests/image-variant-names.xml
     video-layout-source file://{base}/edit/tests/video-layouts.xml
     htmlblock-layout-source file://{base}/edit/tests/htmlblock-layouts.xml
     infobox-layout-source file://{base}/edit/tests/infobox-layouts.xml


### PR DESCRIPTION
Ticket: https://zeit-online.atlassian.net/browse/ZON-2927

Damit die Kombination aus "Modus" und "Variante" nicht in der Konfiguration hinterlegt werden muss, sollen diese Optionen unabhängig voneinander werden.

Needs https://bitbucket.org/zeitonline/vivi-deployment/pull-requests/5
