### PR TITLE
ZON-2882 Separate Keyword Register

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.article changes
 3.20.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Always edit keywords of an article in a separate fold. (ZON-2882)
 
 
 3.20.1 (2016-07-21)

--- a/src/zeit/content/article/edit/browser/form.py
+++ b/src/zeit/content/article/edit/browser/form.py
@@ -279,7 +279,6 @@ class MetadataForms(zeit.edit.browser.form.FoldableFormGroup):
     title = _('Metadata')
 
 
-# This will be renamed properly as soon as the fields are finally decided.
 class MetadataA(zeit.edit.browser.form.InlineForm):
 
     legend = _('')

--- a/src/zeit/content/article/edit/browser/form.py
+++ b/src/zeit/content/article/edit/browser/form.py
@@ -113,13 +113,8 @@ class KeywordsFormGroup(zeit.edit.browser.form.FoldableFormGroup):
 
     title = _('Keywords')
 
-    def render(self):
-        if not IAutomaticallyRenameable(self.context).renameable:
-            return ''
-        return super(KeywordsFormGroup, self).render()
 
-
-class KeywordsNew(zeit.edit.browser.form.InlineForm):
+class Keywords(zeit.edit.browser.form.InlineForm):
 
     legend = _('')
     prefix = 'keywords'
@@ -127,13 +122,8 @@ class KeywordsNew(zeit.edit.browser.form.InlineForm):
     css_class = 'keywords'
     form_fields = FormFields(IArticle).select('keywords')
 
-    def render(self):
-        if not IAutomaticallyRenameable(self.context).renameable:
-            return ''
-        return super(KeywordsNew, self).render()
-
     def setUpWidgets(self, *args, **kw):
-        super(KeywordsNew, self).setUpWidgets(*args, **kw)
+        super(Keywords, self).setUpWidgets(*args, **kw)
         self.widgets['keywords'].show_helptext = True
 
 
@@ -289,23 +279,7 @@ class MetadataForms(zeit.edit.browser.form.FoldableFormGroup):
     title = _('Metadata')
 
 
-class Keywords(zeit.edit.browser.form.InlineForm):
-
-    legend = _('')
-    prefix = 'keywords'
-    undo_description = _('edit keywords')
-    css_class = 'keywords'
-    # XXX this should say ICommonMetadata, but InlineForm does not inherit from
-    # cms.browser.form.EditForm, so form_fields are not post-processed to get
-    # overriden fields
-    form_fields = FormFields(IArticle).select('keywords')
-
-    def __call__(self):
-        if IAutomaticallyRenameable(self.context).renameable:
-            return ''
-        return super(Keywords, self).__call__()
-
-
+# This will be renamed properly as soon as the fields are finally decided.
 class MetadataA(zeit.edit.browser.form.InlineForm):
 
     legend = _('')

--- a/src/zeit/content/article/edit/browser/form.zcml
+++ b/src/zeit/content/article/edit/browser/form.zcml
@@ -140,25 +140,6 @@
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     view=".form.MetadataForms"
     manager="zeit.edit.interfaces.IContentViewletManager"
-    name="edit.form.keywords"
-    class="zeit.edit.browser.form.FormLoader"
-    permission="zope.View"
-    weight="5"
-    />
-
-  <browser:page
-    for="zeit.content.article.interfaces.IArticle"
-    layer="zeit.cms.browser.interfaces.ICMSLayer"
-    name="edit.form.keywords"
-    class=".form.Keywords"
-    permission="zope.View"
-    />
-
-  <browser:viewlet
-    for="zeit.content.article.interfaces.IArticle"
-    layer="zeit.cms.browser.interfaces.ICMSLayer"
-    view=".form.MetadataForms"
-    manager="zeit.edit.interfaces.IContentViewletManager"
     name="edit.form.metadata-a"
     class="zeit.edit.browser.form.FormLoader"
     permission="zope.View"
@@ -805,14 +786,14 @@
     permission="zope.View"
     />
 
-  <!-- keywords (new article only) -->
+  <!-- keywords -->
 
   <browser:viewlet
     for="zeit.content.article.interfaces.IArticle"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     view="zeit.edit.browser.form.Forms"
     manager="zeit.edit.interfaces.IContentViewletManager"
-    name="keywords-new"
+    name="keywords"
     class=".form.KeywordsFormGroup"
     permission="zope.View"
     weight="52"
@@ -823,7 +804,7 @@
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     view=".form.KeywordsFormGroup"
     manager="zeit.edit.interfaces.IContentViewletManager"
-    name="edit.form.keywords-new"
+    name="edit.form.keywords"
     class="zeit.edit.browser.form.FormLoader"
     permission="zope.View"
     weight="10"
@@ -832,8 +813,8 @@
   <browser:page
     for="zeit.content.article.interfaces.IArticle"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
-    name="edit.form.keywords-new"
-    class=".form.KeywordsNew"
+    name="edit.form.keywords"
+    class=".form.Keywords"
     permission="zope.View"
     />
 

--- a/src/zeit/content/article/edit/browser/testing.py
+++ b/src/zeit/content/article/edit/browser/testing.py
@@ -76,7 +76,7 @@ class EditorHelper(object):
 
     def create_block(self, block, wait_for_inline=False):
         s = self.selenium
-        time.sleep(2)
+        s.waitForElementPresent('link=Struktur')
         s.click('link=Struktur')
         s.waitForElementPresent('css=#article-modules .module')
         block_sel = '.block.type-{0}'.format(block)

--- a/src/zeit/content/article/edit/browser/testing.py
+++ b/src/zeit/content/article/edit/browser/testing.py
@@ -1,3 +1,4 @@
+import time
 import transaction
 import zeit.cms.clipboard.interfaces
 import zeit.cms.testing
@@ -75,6 +76,7 @@ class EditorHelper(object):
 
     def create_block(self, block, wait_for_inline=False):
         s = self.selenium
+        time.sleep(2)
         s.click('link=Struktur')
         s.waitForElementPresent('css=#article-modules .module')
         block_sel = '.block.type-{0}'.format(block)

--- a/src/zeit/content/article/edit/browser/tests/test_metadata.py
+++ b/src/zeit/content/article/edit/browser/tests/test_metadata.py
@@ -129,9 +129,9 @@ class KeywordTest(zeit.content.article.edit.browser.testing.EditorTestCase,
         self.add_article()
         s = self.selenium
         s.waitForElementPresent('id=keywords.keywords')
-        s.click('css=#edit-form-keywords-new .fold-link')
+        s.click('css=#edit-form-keywords .fold-link')
         s.assertText(
-            'id=edit-form-keywords-new',
+            'id=edit-form-keywords',
             '*Only the first 6 keywords are shown*')
 
     def test_helptext_should_not_be_shown_for_existing_article(self):

--- a/src/zeit/content/article/edit/browser/tests/test_workflow.py
+++ b/src/zeit/content/article/edit/browser/tests/test_workflow.py
@@ -98,8 +98,8 @@ class CheckinSelenium(
 
         s.click('css=#edit-form-filename .fold-link')
         s.type('new-filename.rename_to', 'asdf\t')
-        s.click('css=#edit-form-keywords-new .edit-bar .fold-link')
-        s.waitForElementNotPresent('css=#edit-form-keywords-new.folded')
+        s.click('css=#edit-form-keywords .edit-bar .fold-link')
+        s.waitForElementNotPresent('css=#edit-form-keywords.folded')
         self.add_keyword_by_autocomplete('testtag', form_prefix='keywords')
         self.add_keyword_by_autocomplete('testtag2', form_prefix='keywords')
         self.add_keyword_by_autocomplete('testtag3', form_prefix='keywords')


### PR DESCRIPTION
As in requested in ZON-2882, a separate register for keywords was implemented also for existing articles.

Additionally to this PR, PR ZeitOnline/zeit.cms#5 was helping me to get the tests running and should also be merged.
