### PR TITLE
ZON-3485: Allow portraitboxes to lack a reference and override fields locally

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.article changes
 3.21.9 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-3485: Allow portraitbox to lack a reference and override fields locally.
 
 
 3.21.8 (2017-01-31)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'zc.sourcefactory',
         'zc.table',
         'zdaemon',
-        'zeit.cms>=2.94.0.dev0',
+        'zeit.cms>=2.95.0.dev0',
         'zeit.connector>=2.3.1.dev0',
         'zeit.content.author>=2.7.1.dev0',
         'zeit.content.cp>=0.33.0',

--- a/src/zeit/content/article/edit/browser/reference.py
+++ b/src/zeit/content/article/edit/browser/reference.py
@@ -76,6 +76,7 @@ class EditGallery(EditBase):
 class EditPortraitbox(EditBase):
 
     interface = zeit.content.article.edit.interfaces.IPortraitbox
+    fields = ('references', 'name', 'text')
     undo_description = _('edit portraitbox block')
 
 

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -402,6 +402,15 @@ class IPortraitbox(IReference, ILayoutable):
         required=False,
         default=u'short')
 
+    name = zope.schema.TextLine(
+        title=_('First and last name'),
+        required=False)
+
+    text = zope.schema.Text(
+        title=_('Text'),
+        required=False,
+        missing_value=u'')
+
 
 class IAuthor(IReference):
 

--- a/src/zeit/content/article/edit/reference.py
+++ b/src/zeit/content/article/edit/reference.py
@@ -145,28 +145,6 @@ def factor_block_from_timeline(body, context, position):
     return block
 
 
-class OverridableProperty(object):
-
-    def __init__(self, name):
-        self.name = name
-
-    def __get__(self, inst, cls):
-        if inst is None:
-            return self
-        field = zeit.content.article.edit.interfaces.IPortraitbox[self.name]
-        value = getattr(inst, '_%s_local' % self.name)
-        if value is not field.missing_value:
-            return value
-        elif inst.references:
-            return getattr(inst.references, self.name)
-        else:
-            field.missing_value
-
-    def __set__(self, inst, value):
-        __traceback_info__ = (self.name, value)
-        setattr(inst, '_%s_local' % self.name, value)
-
-
 class Portraitbox(Reference):
 
     grok.implements(
@@ -179,12 +157,16 @@ class Portraitbox(Reference):
     _name_local = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'name_local',
         zeit.content.article.edit.interfaces.IPortraitbox['name'])
-    name = OverridableProperty('name')
+    name = zeit.cms.content.reference.OverridableProperty(
+        zeit.content.portraitbox.interfaces.IPortraitbox['name'],
+        original='references')
 
     _text_local = zeit.cms.content.property.Structure(
         '.text', 'text_local',
         zeit.content.article.edit.interfaces.IPortraitbox['text'])
-    text = OverridableProperty('text')
+    text = zeit.cms.content.reference.OverridableProperty(
+        zeit.content.portraitbox.interfaces.IPortraitbox['text'],
+        original='references')
 
     def __init__(self, *args, **kw):
         super(Portraitbox, self).__init__(*args, **kw)

--- a/src/zeit/content/article/edit/reference.py
+++ b/src/zeit/content/article/edit/reference.py
@@ -145,6 +145,28 @@ def factor_block_from_timeline(body, context, position):
     return block
 
 
+class OverridableProperty(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, inst, cls):
+        if inst is None:
+            return self
+        field = zeit.content.article.edit.interfaces.IPortraitbox[self.name]
+        value = getattr(inst, '_%s_local' % self.name)
+        if value is not field.missing_value:
+            return value
+        elif inst.references:
+            return getattr(inst.references, self.name)
+        else:
+            field.missing_value
+
+    def __set__(self, inst, value):
+        __traceback_info__ = (self.name, value)
+        setattr(inst, '_%s_local' % self.name, value)
+
+
 class Portraitbox(Reference):
 
     grok.implements(
@@ -153,6 +175,16 @@ class Portraitbox(Reference):
 
     layout = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'layout', zope.schema.TextLine())
+
+    _name_local = zeit.cms.content.property.ObjectPathAttributeProperty(
+        '.', 'name_local',
+        zeit.content.article.edit.interfaces.IPortraitbox['name'])
+    name = OverridableProperty('name')
+
+    _text_local = zeit.cms.content.property.Structure(
+        '.text', 'text_local',
+        zeit.content.article.edit.interfaces.IPortraitbox['text'])
+    text = OverridableProperty('text')
 
     def __init__(self, *args, **kw):
         super(Portraitbox, self).__init__(*args, **kw)

--- a/src/zeit/content/article/edit/rule.py
+++ b/src/zeit/content/article/edit/rule.py
@@ -22,7 +22,8 @@ def content(context):
 
 @glob(zeit.content.article.edit.interfaces.IReference)
 def content(context):
-    field = zope.interface.implementedBy(type(context)).get('references')
+    field = zope.interface.implementedBy(type(
+        zope.security.proxy.getObject(context))).get('references')
     if field.required:
         return [context.references]
     else:

--- a/src/zeit/content/article/edit/rule.py
+++ b/src/zeit/content/article/edit/rule.py
@@ -22,7 +22,11 @@ def content(context):
 
 @glob(zeit.content.article.edit.interfaces.IReference)
 def content(context):
-    return [context.references]
+    field = zope.interface.implementedBy(type(context)).get('references')
+    if field.required:
+        return [context.references]
+    else:
+        return filter(None, [context.references])
 
 
 @glob(zeit.content.article.edit.interfaces.IImage)

--- a/src/zeit/content/article/edit/tests/test_reference.py
+++ b/src/zeit/content/article/edit/tests/test_reference.py
@@ -135,7 +135,7 @@ class TestPortraitbox(ReferenceTest):
         with mock.patch('zeit.content.article.edit.reference.Portraitbox'
                         '.references') as pbox:
             pbox.name = u'ref-name'
-            assert ref.name == u'ref-name'
+            self.assertEqual(ref.name, u'ref-name')
 
     def test_local_name_should_override_value_from_referenced_box(self):
         ref = self.get_ref()
@@ -143,14 +143,14 @@ class TestPortraitbox(ReferenceTest):
                         '.references') as pbox:
             pbox.name = u'ref-name'
             ref.name = u'local-name'
-            assert ref.name == u'local-name'
+            self.assertEqual(ref.name, u'local-name')
 
     def test_default_text_should_be_read_from_referenced_box(self):
         ref = self.get_ref()
         with mock.patch('zeit.content.article.edit.reference.Portraitbox'
                         '.references') as pbox:
             pbox.text = u'ref-text'
-            assert ref.text == u'ref-text'
+            self.assertEqual(ref.text, u'ref-text')
 
     def test_local_text_should_override_value_from_referenced_box(self):
         ref = self.get_ref()
@@ -158,7 +158,7 @@ class TestPortraitbox(ReferenceTest):
                         '.references') as pbox:
             pbox.text = u'ref-text'
             ref.text = u'local-text'
-            assert ref.text == u'local-text'
+            self.assertEqual(ref.text, u'local-text')
 
 
 class TestFactories(zeit.content.article.testing.FunctionalTestCase):

--- a/src/zeit/content/article/edit/tests/test_reference.py
+++ b/src/zeit/content/article/edit/tests/test_reference.py
@@ -130,6 +130,36 @@ class TestPortraitbox(ReferenceTest):
         ref.layout = u'wide'
         self.assertEquals('wide', ref.xml.get('layout'))
 
+    def test_default_name_should_be_read_from_referenced_box(self):
+        ref = self.get_ref()
+        with mock.patch('zeit.content.article.edit.reference.Portraitbox'
+                        '.references') as pbox:
+            pbox.name = u'ref-name'
+            assert ref.name == u'ref-name'
+
+    def test_local_name_should_override_value_from_referenced_box(self):
+        ref = self.get_ref()
+        with mock.patch('zeit.content.article.edit.reference.Portraitbox'
+                        '.references') as pbox:
+            pbox.name = u'ref-name'
+            ref.name = u'local-name'
+            assert ref.name == u'local-name'
+
+    def test_default_text_should_be_read_from_referenced_box(self):
+        ref = self.get_ref()
+        with mock.patch('zeit.content.article.edit.reference.Portraitbox'
+                        '.references') as pbox:
+            pbox.text = u'ref-text'
+            assert ref.text == u'ref-text'
+
+    def test_local_text_should_override_value_from_referenced_box(self):
+        ref = self.get_ref()
+        with mock.patch('zeit.content.article.edit.reference.Portraitbox'
+                        '.references') as pbox:
+            pbox.text = u'ref-text'
+            ref.text = u'local-text'
+            assert ref.text == u'local-text'
+
 
 class TestFactories(zeit.content.article.testing.FunctionalTestCase):
 

--- a/src/zeit/content/article/edit/tests/test_rule.py
+++ b/src/zeit/content/article/edit/tests/test_rule.py
@@ -2,6 +2,7 @@ from zeit.edit.rule import Rule
 import zeit.cms.interfaces
 import zeit.content.article.testing
 import zeit.edit.interfaces
+import zope.security.proxy
 
 
 class RuleTest(zeit.content.article.testing.FunctionalTestCase):
@@ -19,6 +20,7 @@ error_if(True, u'foo')
         self.repository['info'] = zeit.content.infobox.infobox.Infobox()
         block = self.get_factory(self.get_article(), 'infobox')()
         block.references = self.repository['info']
+        block = zope.security.proxy.ProxyFactory(block)
         r = Rule("""
 from zeit.content.infobox.interfaces import IInfobox
 applicable(True)


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.cms/pull/39