### PR TITLE
ZON-3810: Add IElementReferences adapter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.article changes
 3.21.14 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- ZON-3810: Add IElementReferences Adapter
 
 
 3.21.13 (2017-05-05)

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'zeit.content.text>=2.0.2.dev0',
         'zeit.content.video',
         'zeit.content.volume>=1.4.0.dev0',
-        'zeit.edit>=2.14.0.dev0',
+        'zeit.edit>=2.15.0.dev0',
         'zeit.objectlog>=0.2',
         'zeit.push>=1.19.0.dev0',
         'zeit.wysiwyg>=1.41.0dev',

--- a/src/zeit/content/article/article.py
+++ b/src/zeit/content/article/article.py
@@ -220,7 +220,11 @@ def iter_referenced_content(context):
     for element in body.values():
         if zeit.content.article.edit.interfaces.IReference.providedBy(
                 element) and element.references:
-            referenced_content.append(element.references)
+            if zeit.cms.content.interfaces.IReference.providedBy(
+                    element.references):
+                referenced_content.append(element.references.target)
+            else:
+                referenced_content.append(element.references)
     return referenced_content
 
 

--- a/src/zeit/content/article/article.py
+++ b/src/zeit/content/article/article.py
@@ -18,6 +18,8 @@ import zeit.cms.workflow.interfaces
 import zeit.connector.interfaces
 import zeit.content.article.edit.interfaces
 import zeit.content.article.interfaces
+import zeit.content.infobox.interfaces
+import zeit.content.portraitbox.interfaces
 import zeit.edit.interfaces
 import zeit.edit.rule
 import zeit.workflow.interfaces
@@ -27,7 +29,6 @@ import zope.dublincore.interfaces
 import zope.index.text.interfaces
 import zope.interface
 import zope.security.proxy
-
 
 ARTICLE_NS = zeit.content.article.interfaces.ARTICLE_NS
 # supertitle+title+subtitle are here since their order is important for XSLT,
@@ -207,6 +208,20 @@ def disable_is_amp_if_access_is_restricted(article, event):
 
     if article.access and article.access != u'free':
         article.is_amp = False
+
+
+@grok.adapter(zeit.content.article.interfaces.IArticle)
+@grok.implementer(zeit.cms.interfaces.ICMSContentIterable)
+def iter_referenced_content(context):
+    referenced_content = []
+    body = zeit.content.article.edit.interfaces.IEditableBody(context, None)
+    if not body:
+        return referenced_content
+    for element in body.values():
+        if zeit.content.article.edit.interfaces.IReference.providedBy(
+                element) and element.references:
+            referenced_content.append(element.references)
+    return referenced_content
 
 
 class LayoutDependency(object):

--- a/src/zeit/content/article/article.py
+++ b/src/zeit/content/article/article.py
@@ -211,7 +211,7 @@ def disable_is_amp_if_access_is_restricted(article, event):
 
 
 @grok.adapter(zeit.content.article.interfaces.IArticle)
-@grok.implementer(zeit.cms.interfaces.ICMSContentIterable)
+@grok.implementer(zeit.edit.interfaces.IElementReferences)
 def iter_referenced_content(context):
     referenced_content = []
     body = zeit.content.article.edit.interfaces.IEditableBody(context, None)

--- a/src/zeit/content/article/article.py
+++ b/src/zeit/content/article/article.py
@@ -221,7 +221,8 @@ def iter_referenced_content(context):
         if zeit.content.article.edit.interfaces.IReference.providedBy(
                 element) and element.references:
             if zeit.cms.content.interfaces.IReference.providedBy(
-                    element.references):
+                    element.references) and \
+                    element.references.target:
                 referenced_content.append(element.references.target)
             else:
                 referenced_content.append(element.references)

--- a/src/zeit/content/article/edit/browser/tests/test_edit.py
+++ b/src/zeit/content/article/edit/browser/tests/test_edit.py
@@ -124,7 +124,10 @@ class SaveTextTest(TextViewHelper,
     def test_wild_html_should_be_munged_into_paragraph(self):
         view = self.get_view()
         view.request.form['paragraphs'] = ['id-2', 'id-3']
-        view.request.form['text'] = [{'text': u'\n<h3 class="supertitle"><a href="http://www.zeit.de/gesellschaft/zeitgeschehen/2010-12/asasange-festnahme-grossbritannien" title="Vergewaltigungsverdacht - Britische Polizei verhaftet Julian Assange">Vergewaltigungsverdacht</a></h3>\n<h4 class="title"><a href="http://www.zeit.de/gesellschaft/zeitgeschehen/2010-12/asasange-festnahme-grossbritannien" title="Vergewaltigungsverdacht - Britische Polizei verhaftet Julian Assange" rel="bookmark">Britische Polizei verhaftet Julian Assange</a></h4>\n<p>Julian Assange wollte sich "freiwillig" mit der britischen Polizei \ntreffen, doch jetzt klickten die Handschellen. Der untergetauchte \nWikileaks-Gr\xfcnder wurde verhaftet.&nbsp;\n\t    <a href="http://www.zeit.de/gesellschaft/zeitgeschehen/2010-12/asasange-festnahme-grossbritannien" class="more-link" rel="no-follow" title="Vergewaltigungsverdacht - Britische Polizei verhaftet Julian Assange">[weiter\u2026]</a></p>\n', 'factory': 'div'}, {'text': '\n<a><strong></strong></a>', 'factory': 'p'}]
+        view.request.form['text'] = [{'text': u'\n<h3 class="supertitle"><a href="http://www.zeit.de/gesellschaft/zeitgeschehen/2010-12/asasange-festnahme-grossbritannien" title="Vergewaltigungsverdacht - Britische Polizei verhaftet Julian Assange">Vergewaltigungsverdacht</a></h3>\n<h4 class="title"><a href="http://www.zeit.de/gesellschaft/zeitgeschehen/2010-12/asasange-festnahme-grossbritannien" title="Vergewaltigungsverdacht - Britische Polizei verhaftet Julian Assange" rel="bookmark">Britische Polizei verhaftet Julian Assange</a></h4>\n<p>Julian Assange wollte sich "freiwillig" mit der britischen Polizei \ntreffen, doch jetzt klickten die Handschellen. Der untergetauchte \nWikileaks-Gr\xfcnder wurde verhaftet.&nbsp;\n\t    <a href="http://www.zeit.de/gesellschaft/zeitgeschehen/2010-12/asasange-festnahme-grossbritannien" class="more-link" rel="no-follow" title="Vergewaltigungsverdacht - Britische Polizei verhaftet Julian Assange">[weiter\u2026]</a></p>\n',
+                                      'factory': 'div'},
+                                     {'text': '\n<a><strong></strong></a>',
+                                      'factory': 'p'}]
         view.update()
         self.assertEqual('p', view.context['id-7'].type)
 
@@ -147,7 +150,7 @@ class AutoSaveTextTest(TextViewHelper,
 
 
 class TestTextEditing(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def setUp(self):
         super(TestTextEditing, self).setUp()
@@ -291,7 +294,7 @@ class TestTextEditing(
 
 @unittest.skip('Sending arrow keys does not work')
 class TestEditingMultipleParagraphs(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def setUp(self):
         super(TestEditingMultipleParagraphs, self).setUp()
@@ -325,7 +328,7 @@ class TestEditingMultipleParagraphs(
         self.open('/repository/article/@@checkout')
 
     def test_arrow_up_moves_across_non_text_block_and_places_cursor_at_end(
-        self):
+            self):
         s = self.selenium
         second_p = (
             '//*[contains(@class, "block") and contains(@class, "type-p")][2]'
@@ -338,7 +341,7 @@ class TestEditingMultipleParagraphs(
             'window.getSelection().getRangeAt(0).startOffset == 3')
 
     def test_arrow_down_moves_across_non_text_block_and_places_cursor_at_start(
-        self):
+            self):
         s = self.selenium
         first_p = 'css=.block.type-p .editable p'
         s.waitForElementPresent(first_p)
@@ -350,7 +353,7 @@ class TestEditingMultipleParagraphs(
 
 
 class TestLinkEditing(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def setUp(self):
         super(TestLinkEditing, self).setUp()
@@ -646,7 +649,7 @@ class TestLinkEditing(
 
 
 class TestFolding(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def setUp(self):
         super(TestFolding, self).setUp()
@@ -703,7 +706,7 @@ class TestFolding(
 
 
 class TestDivision(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def setUp(self):
         super(TestDivision, self).setUp()
@@ -735,7 +738,7 @@ class TestDivision(
 
 
 class TestLimitedInput(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def setUp(self):
         super(TestLimitedInput, self).setUp()
@@ -759,7 +762,7 @@ class TestLimitedInput(
 
 
 class TestCountedInput(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def setUp(self):
         super(TestCountedInput, self).setUp()
@@ -856,7 +859,7 @@ class TestDummyAd(zeit.content.article.edit.browser.testing.EditorTestCase):
 
 
 class AutoSaveIntegration(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def setUp(self):
         super(AutoSaveIntegration, self).setUp()
@@ -927,7 +930,7 @@ class DirtySaveVersusPersistTests(
 
 @unittest.skip("no typeKeys 'til webdriver")
 class BackButtonPreventionTest(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def test_backspace_somewhere_does_not_cause_back_button(self):
         pass

--- a/src/zeit/content/article/edit/browser/tests/test_html.py
+++ b/src/zeit/content/article/edit/browser/tests/test_html.py
@@ -3,7 +3,7 @@ import zeit.content.article.edit.browser.testing
 
 
 class HTMLConvertTest(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def setUp(self):
         super(HTMLConvertTest, self).setUp()

--- a/src/zeit/content/article/edit/browser/tests/test_replace.py
+++ b/src/zeit/content/article/edit/browser/tests/test_replace.py
@@ -132,7 +132,7 @@ class FindDOMTest(zeit.content.article.testing.SeleniumTestCase):
 
 
 class FindReplaceTest(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def test_finding_text_works_accross_non_text_blocks(self):
         s = self.selenium

--- a/src/zeit/content/article/edit/browser/tests/test_workflow.py
+++ b/src/zeit/content/article/edit/browser/tests/test_workflow.py
@@ -194,7 +194,7 @@ zeit.cms.with_lock = function(callable) {
 
 
 class WorkflowEndToEnd(
-    zeit.content.article.edit.browser.testing.EditorTestCase):
+        zeit.content.article.edit.browser.testing.EditorTestCase):
 
     def test_checkin_redirects_to_repository(self):
         s = self.selenium

--- a/src/zeit/content/article/edit/tests/test_body.py
+++ b/src/zeit/content/article/edit/tests/test_body.py
@@ -117,9 +117,12 @@ class EditableBodyTest(zeit.content.article.testing.FunctionalTestCase):
 
     def test_values_does_not_set_block_ids(self):
         body = self.get_body()
-        find_id_attributes = lambda: body.xml.xpath(
-            '//*[@ns:__name__]',
-            namespaces={'ns': 'http://namespaces.zeit.de/CMS/cp'})
+
+        def find_id_attributes():
+            return body.xml.xpath(
+                '//*[@ns:__name__]',
+                namespaces={'ns': 'http://namespaces.zeit.de/CMS/cp'})
+
         self.assertFalse(find_id_attributes())
         body.values()
         self.assertFalse(find_id_attributes())

--- a/src/zeit/content/article/edit/tests/test_reference.py
+++ b/src/zeit/content/article/edit/tests/test_reference.py
@@ -55,8 +55,8 @@ class ReferenceTest(unittest.TestCase):
         ref = self.get_ref()
         obj = mock.Mock()
         obj.uniqueId = 'my-id'
-        with mock.patch('zeit.cms.content.interfaces.IXMLReferenceUpdater') as\
-            xru:
+        with mock.patch('zeit.cms.content.interfaces.IXMLReferenceUpdater') \
+                as xru:
             ref.references = obj
             xru.assert_called_with(obj, None)
             xru.return_value.update.assert_called_with(ref.xml)

--- a/src/zeit/content/article/edit/tests/test_video.py
+++ b/src/zeit/content/article/edit/tests/test_video.py
@@ -151,7 +151,7 @@ class VideoUpdateTest(zeit.content.article.testing.FunctionalTestCase):
         import zope.component
         self.repository['article'] = self.get_article()
         with zeit.cms.checkout.helper.checked_out(
-            self.repository['article']) as article:
+                self.repository['article']) as article:
             body = zeit.content.article.edit.body.EditableBody(
                 article, article.xml.body)
             factory = zope.component.getAdapter(
@@ -163,7 +163,7 @@ class VideoUpdateTest(zeit.content.article.testing.FunctionalTestCase):
         from zeit.content.video.video import Video
         self.repository['video'] = Video()
         with zeit.cms.checkout.helper.checked_out(
-            self.repository['video']) as co:
+                self.repository['video']) as co:
             co.expires = datetime(2012, 1, 1, tzinfo=pytz.UTC)
 
         with self.video_block() as block:
@@ -174,9 +174,9 @@ class VideoUpdateTest(zeit.content.article.testing.FunctionalTestCase):
             article.xml.body.division.video.get('expires'))
 
 
-class VideoEmptyMarker(
-    zeit.content.article.testing.FunctionalTestCase,
-    zeit.content.article.edit.tests.test_reference.EmptyMarkerTest):
+class VideoEmptyMarker(zeit.content.article.testing.FunctionalTestCase,
+                       zeit.content.article.edit.tests.test_reference
+                       .EmptyMarkerTest):
 
     block_type = 'video'
 

--- a/src/zeit/content/article/tests/test_article.py
+++ b/src/zeit/content/article/tests/test_article.py
@@ -11,6 +11,7 @@ import zeit.cms.section.interfaces
 import zeit.content.article.edit.interfaces
 import zeit.content.article.testing
 import zeit.magazin.interfaces
+import zeit.edit.interfaces
 import zeit.edit.rule
 import zope.component
 import zope.event
@@ -374,14 +375,14 @@ class ArticleCMSContentIterableTest(
         self.repository['pbox'] = pbox
         ref = self.create_empty_portraitbox_reference()
         ref.references = pbox
-        self.assertEqual([pbox], list(zeit.cms.interfaces.ICMSContentIterable(
+        self.assertEqual([pbox], list(zeit.edit.interfaces.IElementReferences(
             self.article)))
 
     def test_articles_cms_iterable_is_empty_if_no_references_are_set(self):
-        self.assertEqual([], list(zeit.cms.interfaces.ICMSContentIterable(
+        self.assertEqual([], list(zeit.edit.interfaces.IElementReferences(
             self.article)))
 
     def test_articles_cms_iterable_is_empty_if_empty_reference_is_set(self):
         self.create_empty_portraitbox_reference()
-        self.assertEqual([], list(zeit.cms.interfaces.ICMSContentIterable(
+        self.assertEqual([], list(zeit.edit.interfaces.IElementReferences(
             self.article)))

--- a/src/zeit/content/article/tests/test_article.py
+++ b/src/zeit/content/article/tests/test_article.py
@@ -355,11 +355,11 @@ class ArticleXMLReferenceUpdate(
             lxml.etree.tostring(reference, pretty_print=True))
 
 
-class ArticleCMSContentIterableTest(
+class ArticleElementReferencesTest(
         zeit.content.article.testing.FunctionalTestCase):
 
     def setUp(self):
-        super(ArticleCMSContentIterableTest, self).setUp()
+        super(ArticleElementReferencesTest, self).setUp()
         self.article = self.get_article()
 
     def create_empty_portraitbox_reference(self):
@@ -369,7 +369,7 @@ class ArticleCMSContentIterableTest(
         portraitbox_reference._validate = mock.Mock()
         return portraitbox_reference
 
-    def test_articles_cms_iterable_iterates_over_refernces(self):
+    def test_articles_element_references_iterates_over_references(self):
         from zeit.content.portraitbox.portraitbox import Portraitbox
         pbox = Portraitbox()
         self.repository['pbox'] = pbox
@@ -378,11 +378,12 @@ class ArticleCMSContentIterableTest(
         self.assertEqual([pbox], list(zeit.edit.interfaces.IElementReferences(
             self.article)))
 
-    def test_articles_cms_iterable_is_empty_if_no_references_are_set(self):
+    def test_articles_element_references_is_empty_if_no_references_are_set(self):
         self.assertEqual([], list(zeit.edit.interfaces.IElementReferences(
             self.article)))
 
-    def test_articles_cms_iterable_is_empty_if_empty_reference_is_set(self):
+    def test_articles_element_references_is_empty_if_empty_reference_is_set(
+            self):
         self.create_empty_portraitbox_reference()
         self.assertEqual([], list(zeit.edit.interfaces.IElementReferences(
             self.article)))


### PR DESCRIPTION
Use the ICMSContentIterable interface from https://github.com/ZeitOnline/zeit.cms/pull/45 to iterate over Referenced ICMS Content in article body.