### PR TITLE
ARBEIT-86 Add citation layout source

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ zeit.content.article changes
 3.25.0 (unreleased)
 -------------------
 
+- ARBEIT-86: Add citation layout source
+
 - ZON-4006: Move mobile fields to their own form
 
 - MAINT: Remove superfluous IEditable interface

--- a/src/zeit/content/article/edit/browser/tests/test_citation.py
+++ b/src/zeit/content/article/edit/browser/tests/test_citation.py
@@ -26,4 +26,4 @@ class FormLoader(zeit.content.article.edit.browser.testing.EditorTestCase):
         s.assertElementPresent('css=.block.type-citation .inline-form '
                                '.field.fieldname-text')
         s.assertElementPresent('css=.block.type-citation .inline-form '
-                               '.field.fieldname-attribution_2')
+                               '.field.fieldname-attribution')

--- a/src/zeit/content/article/edit/browser/tests/test_push.py
+++ b/src/zeit/content/article/edit/browser/tests/test_push.py
@@ -117,4 +117,5 @@ class SocialFBIATest(zeit.content.article.edit.browser.testing.EditorTestCase):
         s.waitForElementNotPresent('css=#form-metadata-access .dirty')
         s.waitForElementPresent(
             'css=.fieldname-is_instant_article .checkboxdisabled')
-        self.assertEqual(False, s.isEditable('css=#social\.is_instant_article'))
+        self.assertEqual(
+            False, s.isEditable('css=#social\.is_instant_article'))

--- a/src/zeit/content/article/edit/citation.py
+++ b/src/zeit/content/article/edit/citation.py
@@ -14,16 +14,10 @@ class Citation(zeit.edit.block.SimpleElement):
 
     text = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'text', zeit.content.article.edit.interfaces.ICitation['text'])
-    text_2 = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.', 'text2', zeit.content.article.edit.interfaces.ICitation['text_2'])
     attribution = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'attribution',
         zeit.content.article.edit.interfaces.ICitation['attribution'])
-    attribution_2 = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.', 'attribution2',
-        zeit.content.article.edit.interfaces.ICitation['attribution_2'])
     url = zeit.cms.content.property.ObjectPathAttributeProperty('.', 'url')
-    url_2 = zeit.cms.content.property.ObjectPathAttributeProperty('.', 'url2')
     layout = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'layout',
         zeit.content.article.edit.interfaces.ICitation['layout'])

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -488,18 +488,6 @@ class ICitation(zeit.edit.interfaces.IBlock):
         title=_('URL'),
         required=False)
 
-    text_2 = zope.schema.Text(
-        title=_('Citation 2'),
-        required=False)
-
-    attribution_2 = zope.schema.TextLine(
-        title=_('Attribution 2'),
-        required=False)
-
-    url_2 = zope.schema.URI(
-        title=_('URL 2'),
-        required=False)
-
     layout = zope.schema.Choice(
         title=_('Layout'),
         source=CitationLayoutSource(),

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -466,13 +466,17 @@ class IAudio(zeit.edit.interfaces.IBlock):
         required=False)
 
 
-class CitationLayoutSource(LayoutSourceBase):
+class CitationLayoutSource(zeit.cms.content.sources.XMLSource):
 
-    values = collections.OrderedDict([
-        (u'short', _('short')),
-        (u'wide', _('wide')),
-        (u'double', _('double')),
-    ])
+    product_configuration = 'zeit.content.article'
+    config_url = 'citation-layout-source'
+    attribute = 'id'
+
+    def isAvailable(self, node, context):
+        article = zeit.content.article.interfaces.IArticle(context, None)
+        return super(CitationLayoutSource, self).isAvailable(node, article)
+
+CITATION_LAYOUT_SOURCE = CitationLayoutSource()
 
 
 class ICitation(zeit.edit.interfaces.IBlock):
@@ -490,7 +494,8 @@ class ICitation(zeit.edit.interfaces.IBlock):
 
     layout = zope.schema.Choice(
         title=_('Layout'),
-        source=CitationLayoutSource(),
+        source=CITATION_LAYOUT_SOURCE,
+        default=u'default',
         required=False)
 
 

--- a/src/zeit/content/article/edit/tests/citation-layouts.xml
+++ b/src/zeit/content/article/edit/tests/citation-layouts.xml
@@ -1,0 +1,4 @@
+<citation-layouts>
+  <layout id="default">Default</layout>
+  <layout id="yellow" available="zeit.arbeit.interfaces.IZARContent">ZAR Only</layout>
+</citation-layouts>

--- a/src/zeit/content/article/testing.py
+++ b/src/zeit/content/article/testing.py
@@ -34,6 +34,7 @@ product_config = """
   infobox-layout-source file://{base}/edit/tests/infobox-layouts.xml
   template-source file://{base}/edit/tests/templates.xml
   header-module-source file://{base}/edit/tests/header-modules.xml
+  citation-layout-source file://{base}/edit/tests/citation-layouts.xml
 </product-config>
 """.format(base=pkg_resources.resource_filename(__name__, ''))
 

--- a/src/zeit/content/article/tests/test_article.py
+++ b/src/zeit/content/article/tests/test_article.py
@@ -294,7 +294,7 @@ class DefaultTemplateByContentType(
 
 
 class AccessRestrictsAMPandFBIA(
-    zeit.content.article.testing.FunctionalTestCase):
+        zeit.content.article.testing.FunctionalTestCase):
 
     def setUp(self):
         super(AccessRestrictsAMPandFBIA, self).setUp()
@@ -403,7 +403,8 @@ class ArticleElementReferencesTest(
         self.assertEqual([], list(zeit.edit.interfaces.IElementReferences(
             self.repository['article_with_empty_ref'])))
 
-    def test_articles_element_references_is_empty_if_no_references_are_set(self):
+    def test_articles_element_references_is_empty_if_no_references_are_set(
+            self):
         self.assertEqual([], list(zeit.edit.interfaces.IElementReferences(
             self.article)))
 


### PR DESCRIPTION
Uses http://vivi.zeit.de/repository/data/article-citation-layouts.xml which defines different layouts for citations, which are used for ZAR.
Needs https://github.com/ZeitOnline/vivi-deployment/pull/40

The second citation fields are deleted because they are not used anyway.