### PR TITLE
ZON-4296: Add version field to liveblog module

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.article changes
 3.32.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-4296: Add version attribute to liveblog.
 
 
 3.32.1 (2017-11-01)

--- a/src/zeit/content/article/edit/browser/tests/test_liveblog.py
+++ b/src/zeit/content/article/edit/browser/tests/test_liveblog.py
@@ -5,7 +5,7 @@ class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
 
     block_type = 'liveblog'
 
-    def test_inline_form_saves_values(self):
+    def test_inline_form_saves_values_without_version(self):
         self.get_article(with_empty_block=True)
         b = self.browser
         b.open(
@@ -14,3 +14,18 @@ class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
         b.getControl('Apply').click()
         b.open('@@edit-%s?show_form=1' % self.block_type)  # XXX
         self.assertEqual('bloggy', b.getControl('Liveblog id').value)
+        self.assertEqual(
+            ['(nothing selected)'],
+            b.getControl('Liveblog version').displayValue)
+
+    def test_inline_form_saves_values_including_version(self):
+        self.get_article(with_empty_block=True)
+        b = self.browser
+        b.open(
+            'editable-body/blockname/@@edit-%s?show_form=1' % self.block_type)
+        b.getControl('Liveblog id').value = 'bloggy'
+        b.getControl('Liveblog version').displayValue = ['3']
+        b.getControl('Apply').click()
+        b.open('@@edit-%s?show_form=1' % self.block_type)
+        self.assertEqual('bloggy', b.getControl('Liveblog id').value)
+        self.assertIn('3', b.getControl('Liveblog version').displayValue)

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -333,11 +333,22 @@ class ICitation(zeit.edit.interfaces.IBlock):
         default=u'default',
         required=False)
 
+class LiveblogVersions(LayoutSourceBase):
+
+    values = collections.OrderedDict([
+        (u'3', '3'),
+    ])
+
 
 class ILiveblog(zeit.edit.interfaces.IBlock):
 
     blog_id = zope.schema.TextLine(
         title=_('Liveblog id'))
+    version = zope.schema.Choice(
+        title=_('Liveblog version'),
+        source=LiveblogVersions(),
+        default=None,
+        required=False)
 
 
 class ICardstack(zeit.edit.interfaces.IBlock):

--- a/src/zeit/content/article/edit/liveblog.py
+++ b/src/zeit/content/article/edit/liveblog.py
@@ -12,6 +12,9 @@ class Liveblog(zeit.content.article.edit.block.Block):
     blog_id = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'blogID',
         zeit.content.article.edit.interfaces.ILiveblog['blog_id'])
+    version = zeit.cms.content.property.ObjectPathAttributeProperty(
+        '.', 'version',
+        zeit.content.article.edit.interfaces.ILiveblog['version'])
 
 
 class Factory(zeit.content.article.edit.block.BlockFactory):

--- a/src/zeit/content/article/edit/tests/test_liveblog.py
+++ b/src/zeit/content/article/edit/tests/test_liveblog.py
@@ -25,3 +25,27 @@ class LSCDefaultTest(zeit.content.article.testing.FunctionalTestCase):
         zeit.cms.workflow.interfaces.IPublishInfo(article).urgent = True
         zeit.cms.workflow.interfaces.IPublish(article).publish()
         self.assertEqual(lsc, ISemanticChange(article).last_semantic_change)
+
+class LiveblogTest(zeit.content.article.testing.FunctionalTestCase):
+
+    def get_liveblog(self):
+        from zeit.content.article.edit.liveblog import Liveblog
+        import lxml.objectify
+        liveblog = Liveblog(None, lxml.objectify.E.liveblog())
+        return liveblog
+
+    def test_liveblog_should_be_set(self):
+        liveblog = self.get_liveblog()
+        liveblog.blog_id = u'290'
+        liveblog.invalid_attribute = 'this should not be set'
+        self.assertEqual(u'290', liveblog.xml.xpath('.')[0].get('blogID'))
+        self.assertIsNone(liveblog.xml.xpath('.')[0].get('version'))
+        self.assertIsNone(liveblog.xml.xpath('.')[0].get('invalid_attribute'))
+
+    def test_liveblog3_should_be_set(self):
+        liveblog = self.get_liveblog()
+        liveblog.blog_id = u'290'
+        liveblog.version = u'3'
+        self.assertEqual(u'290', liveblog.xml.xpath('.')[0].get('blogID'))
+        self.assertEqual(u'3', liveblog.xml.xpath('.')[0].get('version'))
+        self.assertIsNone(liveblog.xml.xpath('.')[0].get('invalid_attribute'))

--- a/src/zeit/content/article/edit/tests/test_liveblog.py
+++ b/src/zeit/content/article/edit/tests/test_liveblog.py
@@ -15,7 +15,7 @@ class LSCDefaultTest(zeit.content.article.testing.FunctionalTestCase):
             co.body.create_item('liveblog')
             self.assertFalse(ISemanticChange(co).has_semantic_change)
 
-    def test_article_with_liveblog_has_lsc_on_checkout(self):
+    def test_article_with_liveblog_old_has_lsc_on_checkout(self):
         with checked_out(self.repository['article']) as co:
             self.assertTrue(ISemanticChange(co).has_semantic_change)
 


### PR DESCRIPTION
Adds versioning to Liveblog element. New versions can be added to LiveblogVersions and current version might be set to "3" after a while, when old Liveblog version should not be used anymore.

**2dos:**
- [x] test version on article (block)