### PR TITLE
ZON-4541: Add new checkbox to hide Ligatus recommendations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.article changes
 3.35.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-4541: Add new checkbox to hide ligatus recommendations
 
 
 3.35.0 (2018-03-22)

--- a/src/zeit/content/article/article.py
+++ b/src/zeit/content/article/article.py
@@ -63,7 +63,8 @@ class Article(zeit.cms.content.metadata.CommonMetadata):
         zeit.content.article.interfaces.IArticle,
         zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
         ('has_recensions', 'artbox_thema', 'layout', 'genre',
-         'template', 'header_layout', 'is_instant_article', 'is_amp'))
+         'template', 'header_layout', 'is_instant_article', 'is_amp',
+         'hide_ligatus_recommendations'))
 
     @property
     def body(self):

--- a/src/zeit/content/article/edit/browser/form.py
+++ b/src/zeit/content/article/edit/browser/form.py
@@ -211,6 +211,9 @@ class InternalLinks(zeit.edit.browser.form.InlineForm):
         zeit.cms.related.interfaces.IRelatedContent,
         zeit.content.article.interfaces.IAggregatedComments,
     )
+    form_fields += FormFields(
+        zeit.content.article.interfaces.IArticleMetadata
+    ).select('hide_ligatus_recommendations')
 
     def setUpWidgets(self, *args, **kw):
         super(InternalLinks, self).setUpWidgets(*args, **kw)

--- a/src/zeit/content/article/interfaces.py
+++ b/src/zeit/content/article/interfaces.py
@@ -84,6 +84,11 @@ class IArticleMetadata(zeit.cms.content.interfaces.ICommonMetadata):
         default=False,
         required=False)
 
+    hide_ligatus_recommendations = zope.schema.Bool(
+        title=_('Hide Ligatus recommendations'),
+        default=False,
+        required=False)
+
 
 class IArticle(IArticleMetadata, zeit.cms.content.interfaces.IXMLContent):
     """Article is the main content type in the Zeit CMS."""


### PR DESCRIPTION
This is just a simple widget used by friedbert to determine whether ligatus
recommendations are displayed or not. Not much to test here I suppose...