### PR TITLE
ZON-3482: Use xml config instead of article for breaking news banner

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.content.article changes
 ============================
 
-3.38.5 (unreleased)
+3.39.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+-ZON-3482: Use xml config instead of article for breaking news banner
 
 
 3.38.4 (2018-06-08)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'zeit.content.volume>=1.4.0.dev0',
         'zeit.edit>=2.17.0.dev0',
         'zeit.objectlog>=0.2',
-        'zeit.push>=1.21.1.dev0',
+        'zeit.push>=1.25.0.dev0',
         'zeit.wysiwyg>=1.41.0dev',
         'zope.app.appsetup',
         'zope.app.component>=3.4.0b3',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.content.article',
-    version='3.38.5.dev0',
+    version='3.39.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/content/article/breaking.py
+++ b/src/zeit/content/article/breaking.py
@@ -4,6 +4,7 @@ import zeit.cms.content.dav
 import zeit.cms.interfaces
 import zeit.connector.interfaces
 import zeit.content.article.interfaces
+import zeit.push.banner
 
 
 class BreakingNews(zeit.cms.content.dav.DAVPropertiesAdapter):
@@ -29,8 +30,8 @@ class BreakingNews(zeit.cms.content.dav.DAVPropertiesAdapter):
     def title(self, value):
         self.context.title = value
 
-    def banner_matches(self, banner):
-        return IBreakingNewsBody(banner).article_id == self.context.uniqueId
+    def banner_matches(self):
+        return self.context == zeit.push.banner.get_breaking_news_article()
 
 
 @grok.adapter(BreakingNews)

--- a/src/zeit/content/article/browser/breaking.py
+++ b/src/zeit/content/article/browser/breaking.py
@@ -159,10 +159,10 @@ class Retract(object):
 
     @property
     def banner_matches(self):
-        return self.breakingnews.banner_matches(self.banner)
+        return self.breakingnews.banner_matches()
 
     @property
     def banner(self):
-        notifier = zope.component.getUtility(
-            zeit.push.interfaces.IPushNotifier, name='homepage')
-        return zeit.cms.interfaces.ICMSContent(notifier.uniqueId)
+        banner = zope.component.getUtility(
+            zeit.push.interfaces.IBanner)
+        return banner.xml_banner

--- a/src/zeit/content/article/browser/tests/test_breaking.py
+++ b/src/zeit/content/article/browser/tests/test_breaking.py
@@ -133,7 +133,7 @@ class TestAdding(zeit.cms.testing.BrowserTestCase):
         self.browser.getControl('Article body').value = ''
         self.browser.getControl('Publish and push').click()
         article = ICMSContent('http://xml.zeit.de/online/2007/01/foo')
-        self.assertEqual(1, len(article.btest_setting_body_text_creates_paragraphody))
+        self.assertEqual(1, len(article.body))
 
     def test_body_text_default_value_is_translated(self):
         b = self.browser

--- a/src/zeit/content/article/browser/tests/test_breaking.py
+++ b/src/zeit/content/article/browser/tests/test_breaking.py
@@ -133,7 +133,7 @@ class TestAdding(zeit.cms.testing.BrowserTestCase):
         self.browser.getControl('Article body').value = ''
         self.browser.getControl('Publish and push').click()
         article = ICMSContent('http://xml.zeit.de/online/2007/01/foo')
-        self.assertEqual(1, len(article.body))
+        self.assertEqual(1, len(article.btest_setting_body_text_creates_paragraphody))
 
     def test_body_text_default_value_is_translated(self):
         b = self.browser
@@ -177,18 +177,13 @@ class RetractBannerTest(zeit.content.article.testing.SeleniumTestCase):
         mocker.start()
         self.addCleanup(mocker.stop)
         super(RetractBannerTest, self).setUp()
-        # Set up dummy banner articles.
-        content = zeit.content.article.testing.create_article()
-        IBreakingNewsBody(content).text = (
-            '<a href="http://xml.zeit.de/online/2007/01/Somalia"/>')
-        self.repository['homepage'] = content
-        notifier = zope.component.getUtility(
-            zeit.push.interfaces.IPushNotifier, name='homepage')
-        notifier.uniqueId = content.uniqueId
-
-        # Publish homepage banner so the retract button is shown.
-        IPublishInfo(self.repository['homepage']).urgent = True
-        IPublish(self.repository['homepage']).publish(async=False)
+        banner_config = zeit.content.rawxml.rawxml.RawXML()
+        banner_config.xml = lxml.etree.fromstring(
+            '<xml><article_id>'
+            'http://xml.zeit.de/online/2007/01/Somalia'
+            '</article_id></xml>')
+        self.repository['banner'] = banner_config
+        IPublish(self.repository['banner']).publish(async=False)
 
         # Make Somalia breaking news, so the retract section is shown.
         article = ICMSContent(

--- a/src/zeit/content/article/edit/body.py
+++ b/src/zeit/content/article/edit/body.py
@@ -215,14 +215,3 @@ class BreakingNewsBody(grok.Adapter):
             if zeit.content.article.edit.interfaces.IParagraph.providedBy(
                     block):
                 return block
-
-    @property
-    def article_id(self):
-        try:
-            anchor = lxml.objectify.fromstring(self.text)
-        except lxml.etree.XMLSyntaxError:
-            return False
-        else:
-            # XXX Duplicates knowlegde of zeit.push.message.Message.url
-            return anchor.get('href').replace(
-                'http://www.zeit.de/', zeit.cms.interfaces.ID_NAMESPACE)

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -304,6 +304,7 @@ class CitationLayoutSource(AvailableBlockLayoutSource):
 
     config_url = 'citation-layout-source'
 
+
 CITATION_LAYOUT_SOURCE = CitationLayoutSource()
 
 
@@ -314,6 +315,7 @@ class BoxLayoutSource(AvailableBlockLayoutSource):
     # and maybe get rid of the superclass
 
     config_url = 'box-layout-source'
+
 
 BOX_LAYOUT_SOURCE = BoxLayoutSource()
 

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -437,9 +437,6 @@ class IBreakingNewsBody(zope.interface.Interface):
         default=_('breaking-news-more-shortly'),
         required=False)
 
-    article_id = zope.interface.Attribute(
-        'The uniqueID of the breaking news article')
-
 
 class IPuzzle(zope.interface.Interface):
     """A puzzle type"""


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.push/pull/29