### PR TITLE
BUG-977: Handle the edge case that the node the user clicked on is one which we need to translate (em/i, strong/b).

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ zeit.content.article changes
 3.42.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- BUG-977: Handle the edge case that the node the user clicked on is one
+  which we need to translate (em/i, strong/b).
 
 
 3.42.0 (2018-12-18)

--- a/src/zeit/content/article/edit/browser/resources/editor.js
+++ b/src/zeit/content/article/edit/browser/resources/editor.js
@@ -733,11 +733,15 @@ zeit.content.article.Editable = gocept.Class.extend({
                     element.removeAttribute('class');
                 }
                 element.removeAttribute('style');
+                var swapped = null;
                 // Yeah, I luv it!
                 if (element.nodeName === 'EM') {
-                    zeit.content.article.html.change_tag(element, 'I');
+                    swapped = zeit.content.article.html.change_tag(element, 'I');
                 } else if (element.nodeName === 'STRONG') {
-                    zeit.content.article.html.change_tag(element, 'B');
+                    swapped = zeit.content.article.html.change_tag(element, 'B');
+                }
+                if (element === self.initial_selection_node) {
+                    self.initial_selection_node = swapped;
                 }
         });
     },

--- a/src/zeit/content/article/edit/browser/resources/html.js
+++ b/src/zeit/content/article/edit/browser/resources/html.js
@@ -32,6 +32,7 @@ zeit.content.article.html.change_tag = function(element, new_name) {
     while (element.firstChild) {
         new_element.appendChild(element.firstChild);
     }
+    return new_element;
 };
 
 


### PR DESCRIPTION
Since changing the tag name is impossible (right?), translating means swapping out the node; so we need to propagate this because otherwise we're left holding a reference to a node that's not part of the DOM anymore.