### PR TITLE
ZON-5017: Add breaking news flag to facebook push

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.article changes
 3.43.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-5017: Add breaking news flag to facebook push
 
 
 3.43.0 (2019-01-11)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'zeit.content.volume>=1.4.0.dev0',
         'zeit.edit>=2.17.0.dev0',
         'zeit.objectlog>=0.2',
-        'zeit.push>=1.26.0.dev0',
+        'zeit.push>=1.28.0.dev0',
         'zeit.wysiwyg>=1.41.0dev',
         'zope.app.appsetup',
         'zope.app.component>=3.4.0b3',

--- a/src/zeit/content/article/browser/breaking.py
+++ b/src/zeit/content/article/browser/breaking.py
@@ -95,6 +95,7 @@ class Add(zeit.cms.browser.form.AddForm,
             message_config.append(
                 {'type': 'facebook', 'enabled': True,
                  'override_text': data['title'],
+                 'breaking_news': True,
                  'account': zeit.push.facebook.facebookAccountSource(
                      self.context).MAIN_ACCOUNT})
             message_config.append(


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.push/pull/32; darf man auch nur zusammen deployen, sonst läuft man Gefahr, dass Eilmeldungsartikel das Flag schon abbekommen, und dann bei einem möglichen späteren erneuten FB-Push es dann auswerten.