### PR TITLE
MAINT: Publish breaking news with the same priority as the homepage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.article changes
 3.44.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- MAINT: Publish breaking news with the same priority as the homepage
 
 
 3.44.2 (2019-02-13)

--- a/src/zeit/content/article/article.py
+++ b/src/zeit/content/article/article.py
@@ -299,6 +299,10 @@ class ArticleWorkflow(zeit.workflow.workflow.ContentWorkflow):
 @grok.adapter(zeit.content.article.interfaces.IArticle)
 @grok.implementer(zeit.cms.workflow.interfaces.IPublishPriority)
 def publish_priority_article(context):
+    # Since breaking news should be published faster articles, we give them
+    # the same priority as the homepage
+    if zeit.content.article.interfaces.IBreakingNews(context).is_breaking:
+        return zeit.cms.workflow.interfaces.PRIORITY_HOMEPAGE
     return zeit.cms.workflow.interfaces.PRIORITY_HIGH
 
 

--- a/src/zeit/content/article/tests/test_breaking.py
+++ b/src/zeit/content/article/tests/test_breaking.py
@@ -1,6 +1,6 @@
 from lxml import etree
 from zeit.cms.checkout.helper import checked_out
-from zeit.content.article.edit.interfaces import IBreakingNewsBody
+import zeit.cms.workflow.interfaces
 from zeit.content.article.interfaces import IBreakingNews
 from zeit.content.article.testing import create_article
 import zeit.content.article.testing
@@ -9,13 +9,29 @@ import zeit.content.rawxml.rawxml
 
 class BreakingNewsTest(zeit.content.article.testing.FunctionalTestCase):
 
-    def test_keywords_are_not_required_for_breaking_news(self):
+    def create_breaking_news_article(self):
         article = zeit.content.article.testing.create_article()
         IBreakingNews(article).is_breaking = True
         self.repository['breaking'] = article
+        return self.repository['breaking']
+
+    def test_keywords_are_not_required_for_breaking_news(self):
+        breaking = self.create_breaking_news_article()
         with self.assertNothingRaised():
-            with checked_out(self.repository['breaking'], temporary=False):
+            with checked_out(breaking, temporary=False):
                 pass
+
+    def test_breaking_news_has_homepage_publish_priority(self):
+        breaking = self.create_breaking_news_article()
+        self.assertEqual(
+            zeit.cms.workflow.interfaces.PRIORITY_HOMEPAGE,
+            zeit.cms.workflow.interfaces.IPublishPriority(breaking)
+        )
+        article = zeit.content.article.testing.create_article()
+        self.assertNotEqual(
+            zeit.cms.workflow.interfaces.PRIORITY_HOMEPAGE,
+            zeit.cms.workflow.interfaces.IPublishPriority(article)
+        )
 
 
 class BreakingBannerTest(zeit.content.article.testing.FunctionalTestCase):


### PR DESCRIPTION
This way we can't accidentally slow down the publication of a breaking news article  by publishing a lot of other articles.

TBH I don't know is this is a great idea. We could slow down the homepage publication this way :)
