### PR TITLE
ZON-5187: Add Topicbox

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.content.article changes
 ============================
 
-3.44.4 (unreleased)
+3.45.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-5187: Add topic box article module
 
 
 3.44.3 (2019-02-19)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.content.article',
-    version='3.44.4.dev0',
+    version='3.45.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/content/article/edit/browser/configure.zcml
+++ b/src/zeit/content/article/edit/browser/configure.zcml
@@ -578,6 +578,28 @@
     weight="10"
     />
 
+  <!-- topicbox -->
+
+  <browser:page
+    for="zeit.content.article.edit.interfaces.ITopicbox"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    name="edit-topicbox"
+    class=".edit.EditTopicbox"
+    permission="zope.View"
+    />
+
+  <browser:viewlet
+    for="zeit.content.article.edit.interfaces.ITopicbox"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    view="zope.interface.Interface"
+    manager="zeit.edit.interfaces.IContentViewletManager"
+    name="edit-topicbox"
+    class="zeit.edit.browser.form.FormLoader"
+    permission="zope.View"
+    weight="10"
+    />
+
+
   <!-- division -->
 
   <browser:viewlet

--- a/src/zeit/content/article/edit/browser/edit.py
+++ b/src/zeit/content/article/edit/browser/edit.py
@@ -387,3 +387,16 @@ class EditMail(zeit.edit.browser.form.InlineForm):
     @property
     def prefix(self):
         return 'mail.{0}'.format(self.context.__name__)
+
+
+class EditTopicbox(zeit.edit.browser.form.InlineForm):
+
+    legend = None
+    form_fields = zope.formlib.form.FormFields(
+        zeit.content.article.edit.interfaces.ITopicbox).omit(
+            '__name__', '__parent__', 'xml')
+    undo_description = _('edit topic box')
+
+    @property
+    def prefix(self):
+        return 'topicbox.{0}'.format(self.context.__name__)

--- a/src/zeit/content/article/edit/browser/tests/test_puzzleform.py
+++ b/src/zeit/content/article/edit/browser/tests/test_puzzleform.py
@@ -8,7 +8,6 @@ class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
     def test_puzzle_inline_form_saves_values(self):
         self.get_article(with_empty_block=True)
         b = self.browser
-        b.handleErrors = False
         b.open(
             'editable-body/blockname/@@edit-%s?show_form=1' % self.block_type)
         b.getControl('Puzzle').displayValue = ['Scrabble']

--- a/src/zeit/content/article/edit/browser/tests/test_topicbox.py
+++ b/src/zeit/content/article/edit/browser/tests/test_topicbox.py
@@ -1,27 +1,42 @@
 import zeit.content.article.edit.browser.testing
+import zeit.content.article.article
 
 
 class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
 
     block_type = 'topicbox'
 
+    def setUp(self):
+        super(Form, self).setUp()
+        self.create_content()
+
+    def create_content(self):
+        import zeit.content.cp.centerpage
+        self.repository['cp'] = zeit.content.cp.centerpage.CenterPage()
+        self.repository['foo'] = zeit.content.article.article.Article()
+        self.repository['bar'] = zeit.content.article.article.Article()
+
     def test_topicbox_form_saves_values(self):
         self.get_article(with_empty_block=True)
         b = self.browser
-        b.handleErrors = False
         b.open(
             'editable-body/blockname/@@edit-%s?show_form=1' % self.block_type)
-        b.getControl('First').value = \
-            'http://xml.zeit.de/online/2007/01/Somalia'
-        b.getControl('Second').value = \
-            'http://xml.zeit.de/online/2007/01/Somalia'
-        b.getControl('Third').value = \
-            'http://xml.zeit.de/online/2007/01/Somalia'
+        b.getControl('Title').value = 'Foo'
+        b.getControl('Supertitle').value = 'Bar'
+        b.getControl('Link').value = 'https://example.com'
+        b.getControl('Linktext').value = 'Baz'
+        b.getControl('Reference', index=0).value = 'http://xml.zeit.de/cp'
+        b.getControl('Reference', index=1).value = 'http://xml.zeit.de/foo'
+        b.getControl('Reference', index=2).value = 'http://xml.zeit.de/bar'
         b.getControl('Apply').click()
         b.open('@@edit-%s?show_form=1' % self.block_type)
-        self.assertEqual('http://xml.zeit.de/online/2007/01/Somalia',
-                         b.getControl('First').value)
-        self.assertEqual('http://xml.zeit.de/online/2007/01/Somalia',
-                         b.getControl('Second').value)
-        self.assertEqual('http://xml.zeit.de/online/2007/01/Somalia',
-                         b.getControl('Third').value)
+        self.assertEqual('Foo', b.getControl('Title').value)
+        self.assertEqual('Bar', b.getControl('Supertitle').value)
+        self.assertEqual('http://xml.zeit.de/cp',
+                         b.getControl('Reference', index=0).value)
+        self.assertEqual('http://xml.zeit.de/foo',
+                         b.getControl('Reference', index=1).value)
+        self.assertEqual('http://xml.zeit.de/bar',
+                         b.getControl('Reference', index=2).value)
+        self.assertEqual('https://example.com', b.getControl('Link').value)
+        self.assertEqual('Baz', b.getControl('Linktext').value)

--- a/src/zeit/content/article/edit/browser/tests/test_topicbox.py
+++ b/src/zeit/content/article/edit/browser/tests/test_topicbox.py
@@ -1,0 +1,27 @@
+import zeit.content.article.edit.browser.testing
+
+
+class Form(zeit.content.article.edit.browser.testing.BrowserTestCase):
+
+    block_type = 'topicbox'
+
+    def test_topicbox_form_saves_values(self):
+        self.get_article(with_empty_block=True)
+        b = self.browser
+        b.handleErrors = False
+        b.open(
+            'editable-body/blockname/@@edit-%s?show_form=1' % self.block_type)
+        b.getControl('First').value = \
+            'http://xml.zeit.de/online/2007/01/Somalia'
+        b.getControl('Second').value = \
+            'http://xml.zeit.de/online/2007/01/Somalia'
+        b.getControl('Third').value = \
+            'http://xml.zeit.de/online/2007/01/Somalia'
+        b.getControl('Apply').click()
+        b.open('@@edit-%s?show_form=1' % self.block_type)
+        self.assertEqual('http://xml.zeit.de/online/2007/01/Somalia',
+                         b.getControl('First').value)
+        self.assertEqual('http://xml.zeit.de/online/2007/01/Somalia',
+                         b.getControl('Second').value)
+        self.assertEqual('http://xml.zeit.de/online/2007/01/Somalia',
+                         b.getControl('Third').value)

--- a/src/zeit/content/article/edit/configure.zcml
+++ b/src/zeit/content/article/edit/configure.zcml
@@ -295,6 +295,17 @@
       />
   </class>
 
+  <class class=".topicbox.Topicbox">
+    <require
+      interface=".interfaces.ITopicbox"
+      permission="zope.View"
+      />
+    <require
+      set_schema=".interfaces.ITopicbox"
+      permission="zeit.EditContent"
+      />
+  </class>
+
   <class class=".box.Box">
     <require
       interface=".interfaces.IBox"

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -568,5 +568,5 @@ class ITopicbox(zeit.edit.interfaces.IBlock):
 
     def values():
         """
-        Iterable of IArticles
+        Iterable of ICMSContent
         """

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -506,12 +506,17 @@ class IPuzzleForm(zeit.edit.interfaces.IBlock):
     )
 
 
-class ITopicReferenceSource(zeit.cms.content.contentsource.CMSContentSource):
+class TopicReferenceSource(zeit.cms.content.contentsource.CMSContentSource):
 
-    check_interfaces = (zeit.content.article.interfaces.IArticle,)
+    def __init__(self, allow_cp=False):
+        self.allow_cp = allow_cp
 
-
-topic_reference_source = ITopicReferenceSource()
+    @property
+    def check_interfaces(self):
+        if not self.allow_cp:
+            return (zeit.content.article.interfaces.IArticle, )
+        return (zeit.content.article.interfaces.IArticle,
+                zeit.content.cp.interfaces.ICenterPage)
 
 
 class ITopicbox(zeit.edit.interfaces.IBlock):
@@ -527,29 +532,26 @@ class ITopicbox(zeit.edit.interfaces.IBlock):
 
     title = zope.schema.TextLine(
         title=_("Title"),
-        required=False,
+        required=True,
         max_length=70)
 
-    # related_content = zope.schema.Tuple(
-    #     title=_('Related Content'),
-    #     default=(),
-    #     max_length=3,
-    #     required=True,
-    #     value_type=zope.schema.Choice(
-    #         source=topic_reference_source))
+    first_reference = zope.schema.Choice(
+        title=_("Reference"),
+        description=_("Drag article or cp here"),
+        source=TopicReferenceSource(allow_cp=True),
+        required=True)
 
-    # first_reference = zope.schema.Choice(
-    #     title=_("Article or Centerpage"),
-    #     source=topic_reference_source,
-    #     required=True)
-    #
-    # second_reference = zope.schema.Choice(
-    #     title=_("Article or Centerpage"),
-    #     source=topic_reference_source)
-    #
-    # third_reference = zope.schema.Choice(
-    #     title=_("Article or Centerpage"),
-    #     source=topic_reference_source)
+    second_reference = zope.schema.Choice(
+        title=_("Reference"),
+        description=_("Drag article here"),
+        source=TopicReferenceSource(),
+        required=False)
+
+    third_reference = zope.schema.Choice(
+        title=_("Reference"),
+        description=_("Drag article here"),
+        source=TopicReferenceSource(),
+        required=False)
 
     link = zope.schema.TextLine(
         title=_('Link'),
@@ -561,8 +563,10 @@ class ITopicbox(zeit.edit.interfaces.IBlock):
         required=False,
         max_length=70)
 
+    referenced_cp = zope.interface.Attribute(
+        'Referenced CP or None')
+
     def values():
         """
-        List of referenced content.
-        :return: List of IArticles
+        Iterable of IArticles
         """

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -504,3 +504,65 @@ class IPuzzleForm(zeit.edit.interfaces.IBlock):
         min=datetime.date.today().year,
         default=datetime.date.today().year,
     )
+
+
+class ITopicReferenceSource(zeit.cms.content.contentsource.CMSContentSource):
+
+    check_interfaces = (zeit.content.article.interfaces.IArticle,)
+
+
+topic_reference_source = ITopicReferenceSource()
+
+
+class ITopicbox(zeit.edit.interfaces.IBlock):
+    """
+    Element which references other Articles
+    """
+
+    supertitle = zope.schema.TextLine(
+        title=_('Supertitle'),
+        description=_('Please take care of capitalisation.'),
+        required=False,
+        max_length=70)
+
+    title = zope.schema.TextLine(
+        title=_("Title"),
+        required=False,
+        max_length=70)
+
+    # related_content = zope.schema.Tuple(
+    #     title=_('Related Content'),
+    #     default=(),
+    #     max_length=3,
+    #     required=True,
+    #     value_type=zope.schema.Choice(
+    #         source=topic_reference_source))
+
+    # first_reference = zope.schema.Choice(
+    #     title=_("Article or Centerpage"),
+    #     source=topic_reference_source,
+    #     required=True)
+    #
+    # second_reference = zope.schema.Choice(
+    #     title=_("Article or Centerpage"),
+    #     source=topic_reference_source)
+    #
+    # third_reference = zope.schema.Choice(
+    #     title=_("Article or Centerpage"),
+    #     source=topic_reference_source)
+
+    link = zope.schema.TextLine(
+        title=_('Link'),
+        required=False,
+        max_length=70)
+
+    link_text = zope.schema.TextLine(
+        title=_("Linktext"),
+        required=False,
+        max_length=70)
+
+    def values():
+        """
+        List of referenced content.
+        :return: List of IArticles
+        """

--- a/src/zeit/content/article/edit/interfaces.py
+++ b/src/zeit/content/article/edit/interfaces.py
@@ -528,12 +528,12 @@ class ITopicbox(zeit.edit.interfaces.IBlock):
         title=_('Supertitle'),
         description=_('Please take care of capitalisation.'),
         required=False,
-        max_length=70)
+        max_length=30)
 
     title = zope.schema.TextLine(
         title=_("Title"),
         required=True,
-        max_length=70)
+        max_length=30)
 
     first_reference = zope.schema.Choice(
         title=_("Reference"),
@@ -555,13 +555,12 @@ class ITopicbox(zeit.edit.interfaces.IBlock):
 
     link = zope.schema.TextLine(
         title=_('Link'),
-        required=False,
-        max_length=70)
+        required=False)
 
     link_text = zope.schema.TextLine(
         title=_("Linktext"),
         required=False,
-        max_length=70)
+        max_length=30)
 
     referenced_cp = zope.interface.Attribute(
         'Referenced CP or None')

--- a/src/zeit/content/article/edit/tests/test_topicbox.py
+++ b/src/zeit/content/article/edit/tests/test_topicbox.py
@@ -2,6 +2,7 @@ import zeit.content.article.article
 import zeit.content.article.edit.interfaces
 import zeit.content.article.testing
 import zeit.edit.interfaces
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 
 
 class TestTopicbox(zeit.content.article.testing.FunctionalTestCase):
@@ -15,6 +16,12 @@ class TestTopicbox(zeit.content.article.testing.FunctionalTestCase):
     def get_cp(self, content=None):
         import zeit.content.cp.centerpage
         self.repository['cp'] = zeit.content.cp.centerpage.CenterPage()
+        if content:
+            region = self.repository['cp'].create_item('region')
+            area = region.create_item('area')
+            for cont in content:
+                teaser = area.create_item('teaser')
+                teaser.insert(0, cont)
         return self.repository['cp']
 
     def test_topicbox_values_does_not_contain_empty_reference(self):
@@ -29,4 +36,33 @@ class TestTopicbox(zeit.content.article.testing.FunctionalTestCase):
         cp = self.get_cp()
         box.first_reference = cp
         self.assertEqual(cp, box.referenced_cp)
-        self.assertEqual([], list(cp.values()))
+        self.assertEqual([], list(box.values()))
+
+    def test_box_uses_cp_content(self):
+        box = self.get_topicbox()
+        article = zeit.cms.interfaces.ICMSContent(
+            "http://xml.zeit.de/online/2007/01/Somalia")
+        cp = self.get_cp(content=[article, ])
+        box.first_reference = cp
+        self.assertEqual([article], list(box.values()))
+
+    def test_box_uses_first_three_cp_entries(self):
+        content = []
+        article_names = ['foo', 'bar', 'baz', 'qux']
+        for name in article_names:
+            self.repository[name] = ExampleContentType()
+            content.append(self.repository[name])
+        box = self.get_topicbox()
+        cp = self.get_cp(content=content)
+        box.first_reference = cp
+        self.assertEqual(cp, box.referenced_cp)
+        self.assertEqual(content[:3], list(box.values()))
+
+    def test_box_if_cp_is_referenced_rest_is_ignored(self):
+        self.repository['foo'] = ExampleContentType()
+        box = self.get_topicbox()
+        cp = self.get_cp(content=[self.repository['foo'],])
+        box.first_reference = cp
+        box.second_reference = zeit.cms.interfaces.ICMSContent(
+            "http://xml.zeit.de/online/2007/01/Somalia")
+        self.assertEqual([self.repository['foo'], ], list(box.values()))

--- a/src/zeit/content/article/edit/tests/test_topicbox.py
+++ b/src/zeit/content/article/edit/tests/test_topicbox.py
@@ -1,0 +1,32 @@
+import zeit.content.article.article
+import zeit.content.article.edit.interfaces
+import zeit.content.article.testing
+import zeit.edit.interfaces
+
+
+class TestTopicbox(zeit.content.article.testing.FunctionalTestCase):
+
+    def get_topicbox(self):
+        from zeit.content.article.edit.topicbox import Topicbox
+        import lxml.objectify
+        box = Topicbox(None, lxml.objectify.E.topicbox())
+        return box
+
+    def get_cp(self, content=None):
+        import zeit.content.cp.centerpage
+        self.repository['cp'] = zeit.content.cp.centerpage.CenterPage()
+        return self.repository['cp']
+
+    def test_topicbox_values_does_not_contain_empty_reference(self):
+        box = self.get_topicbox()
+        article = zeit.cms.interfaces.ICMSContent(
+            "http://xml.zeit.de/online/2007/01/Somalia")
+        box.first_reference = article
+        self.assertEqual([article, ], list(box.values()))
+
+    def test_empty_referenced_cp_has_no_values(self):
+        box = self.get_topicbox()
+        cp = self.get_cp()
+        box.first_reference = cp
+        self.assertEqual(cp, box.referenced_cp)
+        self.assertEqual([], list(cp.values()))

--- a/src/zeit/content/article/edit/topicbox.py
+++ b/src/zeit/content/article/edit/topicbox.py
@@ -3,6 +3,7 @@ from zeit.cms.i18n import MessageFactory as _
 import grokcore.component as grok
 import zeit.content.article.edit.block
 import zeit.content.article.edit.interfaces
+import itertools
 
 
 class Topicbox(zeit.content.article.edit.block.Block):
@@ -11,7 +12,8 @@ class Topicbox(zeit.content.article.edit.block.Block):
     type = 'topicbox'
 
     supertitle = zeit.cms.content.property.ObjectPathAttributeProperty(
-        '.', 'supertitle', zeit.content.article.edit.interfaces.ITopicbox['supertitle'])
+        '.', 'supertitle',
+        zeit.content.article.edit.interfaces.ITopicbox['supertitle'])
 
     title = zeit.cms.content.property.ObjectPathAttributeProperty(
         '.', 'title', zeit.content.article.edit.interfaces.ITopicbox['title'])
@@ -23,23 +25,37 @@ class Topicbox(zeit.content.article.edit.block.Block):
         '.', 'link_text',
         zeit.content.article.edit.interfaces.ITopicbox['link_text'])
 
-    # first_reference = zeit.cms.content.reference.SingleResource(
-    #     '.first_reference', 'first_reference')
-    #
-    # second_reference = zeit.cms.content.reference.SingleResource(
-    #     '.second_reference', 'second_reference')
-    #
-    # third_reference = zeit.cms.content.reference.SingleResource(
-    #     '.third_reference', 'third_reference')
+    first_reference = zeit.cms.content.reference.SingleResource(
+        '.first_reference', 'related')
 
-    # related_content = zeit.cms.content.reference.MultiResource(
-    #     '.related_content.reference', 'related')
+    second_reference = zeit.cms.content.reference.SingleResource(
+        '.second_reference', 'related')
+
+    third_reference = zeit.cms.content.reference.SingleResource(
+        '.third_reference', 'related')
+
+    @property
+    def _reference_properties(self):
+        return (self.first_reference,
+                self.second_reference,
+                self.third_reference)
+
+    @property
+    def referenced_cp(self):
+        import zeit.content.cp.interfaces
+        if zeit.content.cp.interfaces.ICenterPage.providedBy(
+                self.first_reference):
+            return self.first_reference
 
     def values(self):
-        return []
+        if self.referenced_cp:
+            return itertools.islice(
+                zeit.edit.interfaces.IElementReferences(self.referenced_cp),
+                len(self._reference_properties))
+        return (content for content in self._reference_properties if content)
 
 
 class Factory(zeit.content.article.edit.block.BlockFactory):
 
     produces = Topicbox
-    title = _('Topic Box')
+    title = _('Topicbox')

--- a/src/zeit/content/article/edit/topicbox.py
+++ b/src/zeit/content/article/edit/topicbox.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from zeit.cms.i18n import MessageFactory as _
+import grokcore.component as grok
+import zeit.content.article.edit.block
+import zeit.content.article.edit.interfaces
+
+
+class Topicbox(zeit.content.article.edit.block.Block):
+
+    grok.implements(zeit.content.article.edit.interfaces.ITopicbox)
+    type = 'topicbox'
+
+    supertitle = zeit.cms.content.property.ObjectPathAttributeProperty(
+        '.', 'supertitle', zeit.content.article.edit.interfaces.ITopicbox['supertitle'])
+
+    title = zeit.cms.content.property.ObjectPathAttributeProperty(
+        '.', 'title', zeit.content.article.edit.interfaces.ITopicbox['title'])
+
+    link = zeit.cms.content.property.ObjectPathAttributeProperty(
+        '.', 'link', zeit.content.article.edit.interfaces.ITopicbox['link'])
+
+    link_text = zeit.cms.content.property.ObjectPathAttributeProperty(
+        '.', 'link_text',
+        zeit.content.article.edit.interfaces.ITopicbox['link_text'])
+
+    # first_reference = zeit.cms.content.reference.SingleResource(
+    #     '.first_reference', 'first_reference')
+    #
+    # second_reference = zeit.cms.content.reference.SingleResource(
+    #     '.second_reference', 'second_reference')
+    #
+    # third_reference = zeit.cms.content.reference.SingleResource(
+    #     '.third_reference', 'third_reference')
+
+    # related_content = zeit.cms.content.reference.MultiResource(
+    #     '.related_content.reference', 'related')
+
+    def values(self):
+        return []
+
+
+class Factory(zeit.content.article.edit.block.BlockFactory):
+
+    produces = Topicbox
+    title = _('Topic Box')

--- a/src/zeit/content/article/testing.py
+++ b/src/zeit/content/article/testing.py
@@ -3,8 +3,6 @@ import gocept.selenium
 import pkg_resources
 import plone.testing
 import re
-import shutil
-import tempfile
 import zeit.cms.tagging.interfaces
 import zeit.cms.tagging.testing
 import zeit.cms.testing


### PR DESCRIPTION
Ein neues Artikelmodul mit dem man auf anderen Content verweisen kann.
Eventuell wäre es schöner die Referenzen mit `zeit.cms.content.reference.MultiResource` zu modulieren, aber da hakt das JS noch und es wäre schön, wenn das Modul schon benutzt werden könnte.

Friedbert sollte wohl sowieso den Umweg über die `values`  machen.
Übersetzungen werden dann nachgeliefert.